### PR TITLE
Guard against analyzer re-trigger loop via stop_hook_active

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Only when **all** of these are true — otherwise it exits silently and Claude s
 - Watchdog is not disabled (via plugin config or `CLAUDE_WATCHDOG_DISABLED=1`)
 - No `.claude-watchdog-skip` file exists in the project root
 - `stop_reason == "end_turn"` (skips compaction, tool_use pauses, max_tokens cutoffs)
+- `stop_hook_active` is not set — i.e. this Stop is not itself a continuation of a prior Stop-hook run (prevents the analyzer from re-triggering itself in a loop)
 - Session has not already been analyzed (marker in the plugin's data directory, auto-expires after 2 hours)
 - Transcript exists and has ≥ configured minimum tool calls (default 8) in the unanalyzed delta
 - At least the configured cooldown (default 600s) has elapsed since the last analysis for this session

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -212,6 +212,17 @@ try {
     process.exit(0);
   }
 
+  // When this Stop is itself the result of a previous Stop-hook continuation,
+  // Claude Code sets stop_hook_active=true. Without this guard, presenting the
+  // analysis and stopping re-enters the hook, which re-triggers the analyzer —
+  // a feedback loop that the cooldown only dampens, not prevents. This also
+  // covers the case where the Agent tool is unavailable (e.g. acceptEdits mode)
+  // and the model simply stops without running the analyzer.
+  if (event.stop_hook_active === true) {
+    log('SKIP: stop_hook_active is true (avoiding re-trigger loop)');
+    process.exit(0);
+  }
+
   if (hookCwd && existsSync(join(hookCwd, '.claude-watchdog-skip'))) {
     log(`SKIP: disabled via .claude-watchdog-skip in ${hookCwd}`);
     process.exit(0);

--- a/justfile
+++ b/justfile
@@ -411,6 +411,23 @@ test-cursor:
     cleanup_session "$sid17"
     pass "subagent-teammate-skip"
 
+    # --- Test 18: stop_hook_active skip (re-trigger loop guard) ---
+    sid18="cursor-t18-$$"
+    cleanup_session "$sid18"
+    t18_transcript="$TMPROOT/t18.jsonl"
+    mk_transcript "$t18_transcript" 1 5 OLD
+    # Substantial delta that would otherwise fire, but stop_hook_active=true must short-circuit.
+    payload18=$(jq -n --arg sid "$sid18" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:true}')
+    rc=0
+    echo "$payload18" | CLAUDE_WATCHDOG_LOG="$TEST_LOG" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$TEST_LOG"; fail "stop-hook-active-exit" "expected 0 got $rc"; }
+    grep -q "SKIP: stop_hook_active" "$TEST_LOG" || fail "stop-hook-active-log" "no stop_hook_active skip log"
+    [ ! -f "$WATCHDOG_DIR/condensed-${sid18}.txt" ] || fail "stop-hook-active-no-condensed" "condensed file should not exist"
+    [ ! -f "$WATCHDOG_DIR/cursor-${sid18}.txt" ] || fail "stop-hook-active-no-cursor" "cursor should not be created"
+    cleanup_session "$sid18"
+    pass "stop-hook-active"
+
     echo "--- all cursor tests passed ---"
 
 # Test the SubagentStop persistence hook

--- a/justfile
+++ b/justfile
@@ -428,6 +428,21 @@ test-cursor:
     cleanup_session "$sid18"
     pass "stop-hook-active"
 
+    # Positive control: the same substantial delta WITHOUT the flag must still trigger.
+    # Uses a dedicated log so the assertions can't match the skip run above.
+    sid18b="cursor-t18b-$$"
+    cleanup_session "$sid18b"
+    log18b="$TMPROOT/log-t18b"
+    payload18b=$(jq -n --arg sid "$sid18b" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:false}')
+    rc=0
+    echo "$payload18b" | CLAUDE_WATCHDOG_LOG="$log18b" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$log18b"; fail "stop-hook-active-positive-exit" "expected 0 got $rc"; }
+    grep -q "TRIGGER:" "$log18b" || { cat "$log18b"; fail "stop-hook-active-positive-trigger" "expected TRIGGER without the flag"; }
+    if grep -q "SKIP: stop_hook_active" "$log18b"; then fail "stop-hook-active-positive-no-skip" "must not skip when flag is absent/false"; fi
+    cleanup_session "$sid18b"
+    pass "stop-hook-active-positive"
+
     echo "--- all cursor tests passed ---"
 
 # Test the SubagentStop persistence hook


### PR DESCRIPTION
## Problem

When the Stop hook triggers the `session-analyzer`, **presenting that analysis and stopping is itself a Stop event** — which re-enters the hook and can re-trigger the analyzer. The cooldown dampens the frequency but doesn't prevent the echo, and in modes where the Agent tool isn't available (e.g. `acceptEdits`) the model stops quickly and the hook re-fires.

I hit this in a long interactive session: the analyzer fired three times, each time the delta cleared the `MIN_TOOL_USES` gate and the 600s cooldown had elapsed, so both throttles legitimately opened again.

## Fix

Claude Code sets `stop_hook_active = true` on a Stop that is itself the continuation of a prior Stop-hook run. This adds an early guard on that flag — before any cursor/delta processing — mirroring the existing `stop_reason` and subagent (`agent_id`) guards.

```js
if (event.stop_hook_active === true) {
  log('SKIP: stop_hook_active is true (avoiding re-trigger loop)');
  process.exit(0);
}
```

## Changes

- `hooks/session-analysis.mjs` — the guard
- `justfile` — `test-cursor` **Test 18**: a substantial delta that would otherwise fire is skipped when `stop_hook_active=true` (asserts exit 0, the skip log, and no condensed/cursor file)
- `README.md` — documents the condition under "When does the hook actually fire?"

## Verification

Directly exercised the guard both ways:

```
>>> stop_hook_active=true : exit=0
    SKIP: stop_hook_active is true (avoiding re-trigger loop)
    condensed file: none
>>> stop_hook_active=false : exit=0
    TRIGGER: injecting session-analyzer subagent request
```

## Note on existing tests

Heads-up: the `test-cursor` suite currently fails on a clean `main` for me — the `run_hook` helper asserts `exit 2` for a trigger, but the hook now signals via JSON on stdout and exits 0 (Test 2 `first-run` fails first). Looks like what the `ci/node-matrix-and-fix-tests` branch is addressing. I wrote the new Test 18 against the **current** behaviour (a skip → exit 0), so it's consistent once the trigger-path expectations are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)