### PR TITLE
Defer session analysis while background tasks / session crons are in flight

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -62,6 +62,12 @@
       "title": "Interactive recommendations",
       "description": "After session analysis, present actionable recommendations as an interactive multi-select prompt so you can choose which items to address. Selected items are saved to .claude/watchdog-todo.md",
       "default": false
+    },
+    "skip_with_background_tasks": {
+      "type": "boolean",
+      "title": "Skip while background tasks run",
+      "description": "Skip analysis when background tasks (subagents, shell jobs, workflows) are still in flight, so the watchdog only reviews a session that's truly done, not one that's merely paused. Requires Claude Code >= 2.1.145; a no-op on older versions. Default is true",
+      "default": true
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Run a short session and end Claude's turn. You should see output like:
 
 ## Requirements
 
-- **Claude Code** ≥ 1.0 (plugin support)
+- **Claude Code** ≥ 1.0 (plugin support). Background-task awareness — deferring analysis while a subagent, shell job, or workflow is still in flight — needs Claude Code ≥ 2.1.145; it is feature-detected, so on older versions the hook behaves exactly as before.
 - **Node.js** ≥ 18 (for the hook scripts)
 - **git** in the working directory you want analyzed (the agent runs `git diff` to compare intent vs. reality — sessions in non-git dirs still get a transcript-only review)
 
@@ -77,6 +77,8 @@ Only when **all** of these are true — otherwise it exits silently and Claude s
 - No `.claude-watchdog-skip` file exists in the project root
 - `stop_reason == "end_turn"` (skips compaction, tool_use pauses, max_tokens cutoffs)
 - `stop_hook_active` is not set — i.e. this Stop is not itself a continuation of a prior Stop-hook run (prevents the analyzer from re-triggering itself in a loop)
+- No background tasks are in flight (subagents, shell jobs, workflows) — a paused session isn't a finished one, so analysis waits for the next clean stop (unless disabled; requires Claude Code ≥ 2.1.145, no-op on older versions)
+- No session cron is already scheduled to run the analyzer (e.g. a `/loop /analyze-session`) — avoids doubling up. Gated by the **same** `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` flag as the background-task check, so disabling that flag re-enables this case too
 - Session has not already been analyzed (marker in the plugin's data directory, auto-expires after 2 hours)
 - Transcript exists and has ≥ configured minimum tool calls (default 8) in the unanalyzed delta
 - At least the configured cooldown (default 600s) has elapsed since the last analysis for this session
@@ -98,6 +100,7 @@ with `/plugin configure claude-watchdog`:
 | Enable verbose mode | `false` | Prepend a diagnostics header to every condensed transcript and add truncation notices |
 | Store transcripts in project directory | `false` | Store session files under `.claude/tmp/claude-watchdog/` in the project directory instead of the global plugin data path. Eliminates Read permission prompts in `auto` mode. Requires `.claude/` in `.gitignore` |
 | Max transcript size (bytes) | `51200` | Maximum size of the condensed transcript sent to the analyzer (4 KB – 500 KB) |
+| Skip while background tasks run | `true` | Skip analysis when background tasks (subagents, shell jobs, workflows) are still in flight, so the watchdog only reviews a finished session, not a paused one. Requires Claude Code ≥ 2.1.145; a no-op on older versions |
 
 ### Environment variable overrides
 
@@ -110,6 +113,7 @@ take priority over the plugin config. Set these in your shell profile or
 | `CLAUDE_WATCHDOG_DISABLED` | `0` | Set to `1` to disable the hook globally |
 | `CLAUDE_WATCHDOG_MIN_TOOL_USES` | `8` | Override minimum tool calls threshold |
 | `CLAUDE_WATCHDOG_COOLDOWN_SECONDS` | `600` | Override cooldown between analyses |
+| `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` | `1` | Set to `0` to analyze even while background tasks (subagents, shell jobs, workflows) are still in flight. **This flag also gates the session-cron dedup guard** (see below), so setting it to `0` re-enables analysis in both cases |
 
 ### Advanced overrides
 

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -22,6 +22,7 @@ const CURSOR_TTL_DAYS = parseInt(process.env.CLAUDE_WATCHDOG_CURSOR_TTL_DAYS ?? 
 const COOLDOWN_SECONDS = parseInt(cfg('CLAUDE_WATCHDOG_COOLDOWN_SECONDS', 'CLAUDE_PLUGIN_OPTION_COOLDOWN_SECONDS', '600'), 10);
 const LOCAL_STORAGE = cfg('CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE', 'CLAUDE_PLUGIN_OPTION_LOCAL_SESSION_STORAGE', '1');
 const INTERACTIVE_RECS = cfg('CLAUDE_WATCHDOG_INTERACTIVE_RECOMMENDATIONS', 'CLAUDE_PLUGIN_OPTION_INTERACTIVE_RECOMMENDATIONS', '0');
+const SKIP_WITH_BG = cfg('CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS', 'CLAUDE_PLUGIN_OPTION_SKIP_WITH_BACKGROUND_TASKS', '1');
 
 function log(msg) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -221,6 +222,30 @@ try {
   if (event.stop_hook_active === true) {
     log('SKIP: stop_hook_active is true (avoiding re-trigger loop)');
     process.exit(0);
+  }
+
+  // A non-empty background_tasks array means the session is paused with work
+  // still in flight (a subagent, shell job, or workflow), not actually done.
+  // Analyzing now would review a half-finished turn; the next clean Stop — once
+  // the background work settles — analyzes the whole thing. These fields arrive
+  // on the Stop input in Claude Code >= 2.1.145, so older versions (where the
+  // array is absent) feature-detect to a no-op and behave exactly as before.
+  const backgroundTasks = Array.isArray(event.background_tasks) ? event.background_tasks : [];
+  if ((SKIP_WITH_BG === '1' || SKIP_WITH_BG === 'true') && backgroundTasks.length > 0) {
+    const kinds = [...new Set(backgroundTasks.map(t => t.type))].join(',');
+    log(`SKIP: ${backgroundTasks.length} background task(s) in flight (${kinds}); deferring to a clean stop`);
+    process.exit(0);
+  }
+
+  // If a scheduled session cron is already set to run the analyzer (e.g. a user
+  // has `/loop /analyze-session` running), don't double up — let the cron do it.
+  // Gated behind the same opt-out as the background-task guard.
+  if (SKIP_WITH_BG === '1' || SKIP_WITH_BG === 'true') {
+    const crons = Array.isArray(event.session_crons) ? event.session_crons : [];
+    if (crons.some(c => /analyze-session|session-analyzer/i.test(c.prompt || ''))) {
+      log('SKIP: analysis already scheduled via session cron');
+      process.exit(0);
+    }
   }
 
   if (hookCwd && existsSync(join(hookCwd, '.claude-watchdog-skip'))) {

--- a/justfile
+++ b/justfile
@@ -443,6 +443,68 @@ test-cursor:
     cleanup_session "$sid18b"
     pass "stop-hook-active-positive"
 
+    # --- Test 19: background_tasks in flight -> SKIP (session paused, not done) ---
+    sid19="cursor-t19-$$"
+    cleanup_session "$sid19"
+    log19="$TMPROOT/log-t19"
+    # Substantial delta (same transcript Test 20 fires on), but a non-empty
+    # background_tasks array means the session is merely paused -> defer.
+    payload19=$(jq -n --arg sid "$sid19" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"},{type:"shell",id:"s1"}]}')
+    rc=0
+    out=$(echo "$payload19" | CLAUDE_WATCHDOG_LOG="$log19" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "SKIP" ] || { cat "$log19"; fail "bg-tasks-skip-exit" "expected SKIP got $outcome"; }
+    grep -q "SKIP: 2 background task(s) in flight (subagent,shell)" "$log19" || { cat "$log19"; fail "bg-tasks-skip-log" "no background-task skip log"; }
+    [ ! -f "$WATCHDOG_DIR/condensed-${sid19}.txt" ] || fail "bg-tasks-no-condensed" "condensed file should not exist"
+    [ ! -f "$WATCHDOG_DIR/cursor-${sid19}.txt" ] || fail "bg-tasks-no-cursor" "cursor should not be created"
+    cleanup_session "$sid19"
+    pass "background-tasks-skip"
+
+    # --- Test 20: background_tasks absent (old Claude Code) -> TRIGGER (feature-detect) ---
+    sid20="cursor-t20-$$"
+    cleanup_session "$sid20"
+    log20="$TMPROOT/log-t20"
+    # No background_tasks field at all, as on Claude Code < 2.1.145: must behave as before.
+    payload20=$(jq -n --arg sid "$sid20" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    rc=0
+    out=$(echo "$payload20" | CLAUDE_WATCHDOG_LOG="$log20" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "BLOCK" ] || { cat "$log20"; fail "bg-tasks-absent-exit" "expected BLOCK got $outcome"; }
+    if grep -q "background task(s) in flight" "$log20"; then fail "bg-tasks-absent-no-skip" "must not skip when background_tasks is absent"; fi
+    cleanup_session "$sid20"
+    pass "background-tasks-absent-triggers"
+
+    # --- Test 21: opt-out (CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0) -> TRIGGER ---
+    sid21="cursor-t21-$$"
+    cleanup_session "$sid21"
+    log21="$TMPROOT/log-t21"
+    payload21=$(jq -n --arg sid "$sid21" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"}]}')
+    rc=0
+    out=$(echo "$payload21" | CLAUDE_WATCHDOG_LOG="$log21" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "BLOCK" ] || { cat "$log21"; fail "bg-tasks-optout-exit" "expected BLOCK got $outcome (opt-out should let it fire)"; }
+    if grep -q "background task(s) in flight" "$log21"; then fail "bg-tasks-optout-no-skip" "must not skip when opted out"; fi
+    cleanup_session "$sid21"
+    pass "background-tasks-opt-out"
+
+    # --- Test 22: session cron already scheduled for the analyzer -> SKIP ---
+    sid22="cursor-t22-$$"
+    cleanup_session "$sid22"
+    log22="$TMPROOT/log-t22"
+    payload22=$(jq -n --arg sid "$sid22" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", session_crons:[{prompt:"/loop /analyze-session"}]}')
+    rc=0
+    out=$(echo "$payload22" | CLAUDE_WATCHDOG_LOG="$log22" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "SKIP" ] || { cat "$log22"; fail "session-cron-skip-exit" "expected SKIP got $outcome"; }
+    grep -q "SKIP: analysis already scheduled via session cron" "$log22" || { cat "$log22"; fail "session-cron-skip-log" "no session-cron skip log"; }
+    [ ! -f "$WATCHDOG_DIR/condensed-${sid22}.txt" ] || fail "session-cron-no-condensed" "condensed file should not exist"
+    cleanup_session "$sid22"
+    pass "session-cron-skip"
+
     echo "--- all cursor tests passed ---"
 
 # Test the SubagentStop persistence hook


### PR DESCRIPTION
## Summary

The Stop hook hijacked stops that were merely **paused** for in-flight background work — the live incident was it firing while a background research subagent was still running, so it reviewed a half-finished turn. This adds feature-detected awareness of the `background_tasks` / `session_crons` Stop-input fields (Claude Code ≥ 2.1.145).

## Changes

**`hooks/session-analysis.mjs`** — new `SKIP_WITH_BG` config (via the existing `cfg()` pattern) and two early-exit guards placed right after the `stop_hook_active` guard:
- **background_tasks**: a non-empty array means the session is paused, not done → defer to the next clean Stop. `Array.isArray(...)` feature-detection makes it a **no-op on older Claude Code** where the field is absent.
- **session_crons**: skip if a scheduled cron's prompt already references the analyzer (e.g. `/loop /analyze-session`), to avoid doubling up.

Both guards are gated behind a **single opt-out** (`CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` / `skip_with_background_tasks`, default on). The coupling — disabling the flag re-enables analysis in *both* cases — is documented in the README (firing-conditions list + env-var table) and an inline comment.

**`.claude-plugin/plugin.json`** — `skip_with_background_tasks` boolean userConfig (default `true`).

**`justfile`** — Tests 19–22: bg-tasks present → SKIP, bg-tasks absent → TRIGGER (feature-detect safety), opt-out (`=0`) → TRIGGER, session-cron → SKIP.

**`README.md`** — firing-condition bullets, config-table row, env-var-override row, and a Requirements note (background-task awareness needs Claude Code ≥ 2.1.145; feature-detected, so no forced version bump).

## Testing

`just check` — lint + all 23 cursor tests (incl. the 4 new ones) + persist tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
