### PR TITLE
Scope the stop_hook_active guard to our own analyzer echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Only when **all** of these are true — otherwise it exits silently and Claude s
 - Watchdog is not disabled (via plugin config or `CLAUDE_WATCHDOG_DISABLED=1`)
 - No `.claude-watchdog-skip` file exists in the project root
 - `stop_reason == "end_turn"` (skips compaction, tool_use pauses, max_tokens cutoffs)
-- `stop_hook_active` is not set — i.e. this Stop is not itself a continuation of a prior Stop-hook run (prevents the analyzer from re-triggering itself in a loop)
+- This Stop is not the watchdog's own analyzer echo (tracked via a per-session sentinel) — continuations triggered by other plugins' Stop hooks are not suppressed
 - No background tasks are in flight (subagents, shell jobs, workflows) — a paused session isn't a finished one, so analysis waits for the next clean stop (unless disabled; requires Claude Code ≥ 2.1.145, no-op on older versions)
 - No session cron is already scheduled to run the analyzer (e.g. a `/loop /analyze-session`) — avoids doubling up. Gated by the **same** `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` flag as the background-task check, so disabling that flag re-enables this case too
 - Session has not already been analyzed (marker in the plugin's data directory, auto-expires after 2 hours)

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -52,7 +52,7 @@ function cleanupSessionsDir(dir) {
       try {
         if (entry.isFile()) {
           const age = now - statSync(full).mtimeMs;
-          if (/^(condensed|raw|delta)-/.test(entry.name) && age > twoHoursMs) {
+          if (/^(condensed|raw|delta|echo)-/.test(entry.name) && age > twoHoursMs) {
             unlinkSync(full);
           } else if (/^cursor-/.test(entry.name) && age > cursorTtlMs) {
             unlinkSync(full);
@@ -196,6 +196,13 @@ try {
     process.exit(0);
   }
 
+  // One-shot self-owned sentinel. We drop this file whenever we block (trigger the
+  // analyzer), and the very next Stop that carries stop_hook_active=true is treated
+  // as our own analyzer echo and suppressed. It lives in GLOBAL_SESSIONS_DIR (created
+  // early, before the local/global SESSIONS_DIR decision) so it resolves identically
+  // on the block turn and the echo turn regardless of LOCAL_STORAGE.
+  const ECHO_FILE = join(GLOBAL_SESSIONS_DIR, `echo-${sessionId}`);
+
   if (event.agent_id) {
     log(`SKIP: running inside subagent/teammate (agent_id=${event.agent_id}, agent_type=${event.agent_type ?? 'unknown'})`);
     process.exit(0);
@@ -213,16 +220,29 @@ try {
     process.exit(0);
   }
 
-  // When this Stop is itself the result of a previous Stop-hook continuation,
-  // Claude Code sets stop_hook_active=true. Without this guard, presenting the
-  // analysis and stopping re-enters the hook, which re-triggers the analyzer —
-  // a feedback loop that the cooldown only dampens, not prevents. This also
-  // covers the case where the Agent tool is unavailable (e.g. acceptEdits mode)
-  // and the model simply stops without running the analyzer.
-  if (event.stop_hook_active === true) {
-    log('SKIP: stop_hook_active is true (avoiding re-trigger loop)');
+  // Suppress only the continuation that follows OUR OWN block, not every
+  // continuation. Claude Code sets stop_hook_active=true on any Stop that is itself
+  // the result of a Stop-hook block — including blocks from co-installed plugins
+  // (e.g. a "run tests before stopping" hook). Keying purely on that flag (as #8
+  // did) would make the watchdog silently never fire for users running such a
+  // plugin. So we only skip when stop_hook_active is set AND our own echo sentinel
+  // is present — proof the prior block was ours.
+  const weBlockedLast = existsSync(ECHO_FILE);
+  if (event.stop_hook_active === true && weBlockedLast) {
+    try { unlinkSync(ECHO_FILE); } catch { /* already gone */ }
+    log('SKIP: our own analyzer echo (stop_hook_active + echo sentinel)');
     process.exit(0);
   }
+  if (weBlockedLast && event.stop_hook_active !== true) {
+    // The continuation chain ended and the user did fresh work (this Stop is a real
+    // end_turn, not a continuation). Clear the stale sentinel so it can't suppress a
+    // genuine later echo, then proceed.
+    try { unlinkSync(ECHO_FILE); } catch { /* already gone */ }
+    log('ECHO: stale sentinel cleared (fresh turn, not a continuation)');
+  }
+  // stop_hook_active===true with NO sentinel => another plugin's continuation:
+  // do NOT skip here; fall through to the cooldown / cursor / MIN_TOOL_USES gates,
+  // which still prevent runaway re-triggering.
 
   // A non-empty background_tasks array means the session is paused with work
   // still in flight (a subagent, shell job, or workflow), not actually done.
@@ -446,6 +466,11 @@ ${postAnalysis}`;
       log('CURSOR: invalid last-uuid output, cursor unchanged');
     }
   }
+
+  // Drop the self-owned sentinel just before we block, so the analyzer's resulting
+  // Stop (which carries stop_hook_active=true) is recognized as our own echo and
+  // suppressed exactly once. Covers both the JSON-block and legacy exit-2 paths.
+  try { writeFileSync(ECHO_FILE, new Date().toISOString() + '\n'); } catch { /* sentinel best-effort; cooldown+cursor+MIN_TOOL_USES still gate the echo */ }
 
   if (useLegacyExit2) {
     process.stderr.write(instruction + '\n');

--- a/justfile
+++ b/justfile
@@ -19,7 +19,9 @@ smoke:
     session_id="smoketest-$$"
     # Default storage is project-local ($PWD/.claude); the hook receives cwd=$PWD below.
     sessions="$PWD/.claude/tmp/claude-watchdog/sessions"
-    trap 'rm -rf "$tmpdir"; rmdir "$sessions/${session_id}" 2>/dev/null || true; rm -f "$sessions/condensed-${session_id}.txt" "$sessions/raw-${session_id}.txt" "$sessions/cursor-${session_id}.txt" "$sessions/delta-${session_id}.tmp" "$HOME/.claude/logs/claude-watchdog-analyses/${session_id}-"*.md 2>/dev/null || true' EXIT
+    # The echo sentinel always lives in the global sessions dir (it must resolve before
+    # the local/global decision), so clean it from there regardless of local storage.
+    trap 'rm -rf "$tmpdir"; rmdir "$sessions/${session_id}" 2>/dev/null || true; rm -f "$sessions/condensed-${session_id}.txt" "$sessions/raw-${session_id}.txt" "$sessions/cursor-${session_id}.txt" "$sessions/delta-${session_id}.tmp" "$HOME/.claude/tmp/claude-watchdog/sessions/echo-${session_id}" "$HOME/.claude/logs/claude-watchdog-analyses/${session_id}-"*.md 2>/dev/null || true' EXIT
     transcript="$tmpdir/transcript.jsonl"
     for i in $(seq 1 5); do
       printf '{"type":"user","message":{"content":"do task %s"}}\n' "$i" >> "$transcript"
@@ -102,6 +104,7 @@ test-cursor:
             "$WATCHDOG_DIR/condensed-${sid}.txt" \
             "$WATCHDOG_DIR/raw-${sid}.txt" \
             "$WATCHDOG_DIR/delta-${sid}.tmp" \
+            "$WATCHDOG_DIR/echo-${sid}" \
             "$HOME/.claude/logs/claude-watchdog-analyses/${sid}-"*.md 2>/dev/null || true
       rmdir "$WATCHDOG_DIR/${sid}" 2>/dev/null || true
     }
@@ -411,98 +414,138 @@ test-cursor:
     cleanup_session "$sid17"
     pass "subagent-teammate-skip"
 
-    # --- Test 18: stop_hook_active skip (re-trigger loop guard) ---
+    # --- Test 18: echo-cycle (suppress our own analyzer echo exactly once) ---
     sid18="cursor-t18-$$"
     cleanup_session "$sid18"
     t18_transcript="$TMPROOT/t18.jsonl"
     mk_transcript "$t18_transcript" 1 5 OLD
-    # Substantial delta that would otherwise fire, but stop_hook_active=true must short-circuit.
-    payload18=$(jq -n --arg sid "$sid18" --arg tp "$t18_transcript" --arg cwd "$PWD" \
-      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:true}')
-    rc=0
-    echo "$payload18" | CLAUDE_WATCHDOG_LOG="$TEST_LOG" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
-    [ "$rc" = "0" ] || { cat "$TEST_LOG"; fail "stop-hook-active-exit" "expected 0 got $rc"; }
-    grep -q "SKIP: stop_hook_active" "$TEST_LOG" || fail "stop-hook-active-log" "no stop_hook_active skip log"
-    [ ! -f "$WATCHDOG_DIR/condensed-${sid18}.txt" ] || fail "stop-hook-active-no-condensed" "condensed file should not exist"
-    [ ! -f "$WATCHDOG_DIR/cursor-${sid18}.txt" ] || fail "stop-hook-active-no-cursor" "cursor should not be created"
-    cleanup_session "$sid18"
-    pass "stop-hook-active"
-
-    # Positive control: the same substantial delta WITHOUT the flag must still trigger.
-    # Uses a dedicated log so the assertions can't match the skip run above.
-    sid18b="cursor-t18b-$$"
-    cleanup_session "$sid18b"
-    log18b="$TMPROOT/log-t18b"
-    payload18b=$(jq -n --arg sid "$sid18b" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+    # Phase 1: substantial delta, fresh turn (stop_hook_active:false) -> TRIGGER and
+    # the self-owned echo sentinel must now exist.
+    log18p1="$TMPROOT/log-t18p1"
+    payload18p1=$(jq -n --arg sid "$sid18" --arg tp "$t18_transcript" --arg cwd "$PWD" \
       '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:false}')
     rc=0
-    echo "$payload18b" | CLAUDE_WATCHDOG_LOG="$log18b" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
-    [ "$rc" = "0" ] || { cat "$log18b"; fail "stop-hook-active-positive-exit" "expected 0 got $rc"; }
-    grep -q "TRIGGER:" "$log18b" || { cat "$log18b"; fail "stop-hook-active-positive-trigger" "expected TRIGGER without the flag"; }
-    if grep -q "SKIP: stop_hook_active" "$log18b"; then fail "stop-hook-active-positive-no-skip" "must not skip when flag is absent/false"; fi
-    cleanup_session "$sid18b"
-    pass "stop-hook-active-positive"
+    echo "$payload18p1" | CLAUDE_WATCHDOG_LOG="$log18p1" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$log18p1"; fail "echo-cycle-p1-exit" "expected 0 got $rc"; }
+    grep -q "TRIGGER:" "$log18p1" || { cat "$log18p1"; fail "echo-cycle-p1-trigger" "expected TRIGGER on the first (fresh) turn"; }
+    [ -f "$WATCHDOG_DIR/echo-${sid18}" ] || fail "echo-cycle-p1-sentinel" "echo sentinel not written after TRIGGER"
+    # Phase 2: same sid, the analyzer's resulting Stop carries stop_hook_active:true.
+    # Fresh log so the assertion can't match Phase 1. Cooldown=0 proves the echo
+    # sentinel (not the cooldown) is what suppresses this turn.
+    log18p2="$TMPROOT/log-t18p2"
+    payload18p2=$(jq -n --arg sid "$sid18" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:true}')
+    rc=0
+    echo "$payload18p2" | CLAUDE_WATCHDOG_LOG="$log18p2" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$log18p2"; fail "echo-cycle-p2-exit" "expected 0 got $rc"; }
+    grep -q "SKIP: our own analyzer echo" "$log18p2" || { cat "$log18p2"; fail "echo-cycle-p2-skip" "expected our-own-echo skip log"; }
+    if grep -q "TRIGGER:" "$log18p2"; then fail "echo-cycle-p2-no-trigger" "must not trigger on our own echo"; fi
+    [ ! -f "$WATCHDOG_DIR/echo-${sid18}" ] || fail "echo-cycle-p2-sentinel-cleared" "echo sentinel must be removed after the skip"
+    cleanup_session "$sid18"
+    pass "echo-cycle"
 
-    # --- Test 19: background_tasks in flight -> SKIP (session paused, not done) ---
+    # --- Test 19: foreign continuation still fires (encodes the #8 fix) ---
+    # stop_hook_active:true but NO echo sentinel => the continuation came from another
+    # plugin's Stop hook, not ours. The watchdog MUST NOT suppress it. (Under #8's
+    # flag-only guard this would have been wrongly skipped.)
     sid19="cursor-t19-$$"
     cleanup_session "$sid19"
+    t19_transcript="$TMPROOT/t19.jsonl"
+    mk_transcript "$t19_transcript" 1 5 OLD
     log19="$TMPROOT/log-t19"
-    # Substantial delta (same transcript Test 20 fires on), but a non-empty
-    # background_tasks array means the session is merely paused -> defer.
-    payload19=$(jq -n --arg sid "$sid19" --arg tp "$t18_transcript" --arg cwd "$PWD" \
-      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"},{type:"shell",id:"s1"}]}')
+    payload19=$(jq -n --arg sid "$sid19" --arg tp "$t19_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:true}')
     rc=0
-    out=$(echo "$payload19" | CLAUDE_WATCHDOG_LOG="$log19" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
-    outcome=$(hook_outcome "$out" "$rc")
-    [ "$outcome" = "SKIP" ] || { cat "$log19"; fail "bg-tasks-skip-exit" "expected SKIP got $outcome"; }
-    grep -q "SKIP: 2 background task(s) in flight (subagent,shell)" "$log19" || { cat "$log19"; fail "bg-tasks-skip-log" "no background-task skip log"; }
-    [ ! -f "$WATCHDOG_DIR/condensed-${sid19}.txt" ] || fail "bg-tasks-no-condensed" "condensed file should not exist"
-    [ ! -f "$WATCHDOG_DIR/cursor-${sid19}.txt" ] || fail "bg-tasks-no-cursor" "cursor should not be created"
+    echo "$payload19" | CLAUDE_WATCHDOG_LOG="$log19" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$log19"; fail "foreign-continuation-exit" "expected 0 got $rc"; }
+    grep -q "TRIGGER:" "$log19" || { cat "$log19"; fail "foreign-continuation-trigger" "expected TRIGGER for a foreign continuation"; }
+    if grep -q "SKIP: our own analyzer echo" "$log19"; then fail "foreign-continuation-no-skip" "must not treat a foreign continuation as our echo"; fi
     cleanup_session "$sid19"
-    pass "background-tasks-skip"
+    pass "foreign-continuation"
 
-    # --- Test 20: background_tasks absent (old Claude Code) -> TRIGGER (feature-detect) ---
+    # --- Test 20: stale sentinel + fresh turn clears, then still fires ---
+    # A leftover sentinel (we blocked but the analyzer's echo Stop never arrived, e.g.
+    # the session closed). On a fresh end_turn it must be cleared, not treated as an
+    # echo, and the substantial delta must still TRIGGER.
     sid20="cursor-t20-$$"
     cleanup_session "$sid20"
+    t20_transcript="$TMPROOT/t20.jsonl"
+    mk_transcript "$t20_transcript" 1 5 OLD
+    printf 'stale-marker\n' > "$WATCHDOG_DIR/echo-${sid20}"
     log20="$TMPROOT/log-t20"
-    # No background_tasks field at all, as on Claude Code < 2.1.145: must behave as before.
-    payload20=$(jq -n --arg sid "$sid20" --arg tp "$t18_transcript" --arg cwd "$PWD" \
-      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    payload20=$(jq -n --arg sid "$sid20" --arg tp "$t20_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", stop_hook_active:false}')
     rc=0
-    out=$(echo "$payload20" | CLAUDE_WATCHDOG_LOG="$log20" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
-    outcome=$(hook_outcome "$out" "$rc")
-    [ "$outcome" = "BLOCK" ] || { cat "$log20"; fail "bg-tasks-absent-exit" "expected BLOCK got $outcome"; }
-    if grep -q "background task(s) in flight" "$log20"; then fail "bg-tasks-absent-no-skip" "must not skip when background_tasks is absent"; fi
+    echo "$payload20" | CLAUDE_WATCHDOG_LOG="$log20" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "0" ] || { cat "$log20"; fail "stale-sentinel-exit" "expected 0 got $rc"; }
+    grep -q "ECHO: stale sentinel cleared" "$log20" || { cat "$log20"; fail "stale-sentinel-log" "expected stale-sentinel-cleared log"; }
+    grep -q "TRIGGER:" "$log20" || { cat "$log20"; fail "stale-sentinel-trigger" "expected TRIGGER after clearing the stale sentinel"; }
+    # The stale sentinel was removed; the TRIGGER then writes a fresh timestamped one,
+    # so the file exists but no longer holds the stale marker.
+    if grep -q "stale-marker" "$WATCHDOG_DIR/echo-${sid20}" 2>/dev/null; then fail "stale-sentinel-not-cleared" "stale sentinel content survived"; fi
     cleanup_session "$sid20"
-    pass "background-tasks-absent-triggers"
+    pass "stale-sentinel"
 
-    # --- Test 21: opt-out (CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0) -> TRIGGER ---
+    # --- Test 21: background_tasks in flight -> SKIP (session paused, not done) ---
     sid21="cursor-t21-$$"
     cleanup_session "$sid21"
     log21="$TMPROOT/log-t21"
+    # Substantial delta (same transcript Test 22 fires on), but a non-empty
+    # background_tasks array means the session is merely paused -> defer.
     payload21=$(jq -n --arg sid "$sid21" --arg tp "$t18_transcript" --arg cwd "$PWD" \
-      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"}]}')
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"},{type:"shell",id:"s1"}]}')
     rc=0
-    out=$(echo "$payload21" | CLAUDE_WATCHDOG_LOG="$log21" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    out=$(echo "$payload21" | CLAUDE_WATCHDOG_LOG="$log21" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
     outcome=$(hook_outcome "$out" "$rc")
-    [ "$outcome" = "BLOCK" ] || { cat "$log21"; fail "bg-tasks-optout-exit" "expected BLOCK got $outcome (opt-out should let it fire)"; }
-    if grep -q "background task(s) in flight" "$log21"; then fail "bg-tasks-optout-no-skip" "must not skip when opted out"; fi
+    [ "$outcome" = "SKIP" ] || { cat "$log21"; fail "bg-tasks-skip-exit" "expected SKIP got $outcome"; }
+    grep -q "SKIP: 2 background task(s) in flight (subagent,shell)" "$log21" || { cat "$log21"; fail "bg-tasks-skip-log" "no background-task skip log"; }
+    [ ! -f "$WATCHDOG_DIR/condensed-${sid21}.txt" ] || fail "bg-tasks-no-condensed" "condensed file should not exist"
+    [ ! -f "$WATCHDOG_DIR/cursor-${sid21}.txt" ] || fail "bg-tasks-no-cursor" "cursor should not be created"
     cleanup_session "$sid21"
-    pass "background-tasks-opt-out"
+    pass "background-tasks-skip"
 
-    # --- Test 22: session cron already scheduled for the analyzer -> SKIP ---
+    # --- Test 22: background_tasks absent (old Claude Code) -> TRIGGER (feature-detect) ---
     sid22="cursor-t22-$$"
     cleanup_session "$sid22"
     log22="$TMPROOT/log-t22"
+    # No background_tasks field at all, as on Claude Code < 2.1.145: must behave as before.
     payload22=$(jq -n --arg sid "$sid22" --arg tp "$t18_transcript" --arg cwd "$PWD" \
-      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", session_crons:[{prompt:"/loop /analyze-session"}]}')
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
     rc=0
     out=$(echo "$payload22" | CLAUDE_WATCHDOG_LOG="$log22" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
     outcome=$(hook_outcome "$out" "$rc")
-    [ "$outcome" = "SKIP" ] || { cat "$log22"; fail "session-cron-skip-exit" "expected SKIP got $outcome"; }
-    grep -q "SKIP: analysis already scheduled via session cron" "$log22" || { cat "$log22"; fail "session-cron-skip-log" "no session-cron skip log"; }
-    [ ! -f "$WATCHDOG_DIR/condensed-${sid22}.txt" ] || fail "session-cron-no-condensed" "condensed file should not exist"
+    [ "$outcome" = "BLOCK" ] || { cat "$log22"; fail "bg-tasks-absent-exit" "expected BLOCK got $outcome"; }
+    if grep -q "background task(s) in flight" "$log22"; then fail "bg-tasks-absent-no-skip" "must not skip when background_tasks is absent"; fi
     cleanup_session "$sid22"
+    pass "background-tasks-absent-triggers"
+
+    # --- Test 23: opt-out (CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0) -> TRIGGER ---
+    sid23="cursor-t23-$$"
+    cleanup_session "$sid23"
+    log23="$TMPROOT/log-t23"
+    payload23=$(jq -n --arg sid "$sid23" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", background_tasks:[{type:"subagent",id:"a1"}]}')
+    rc=0
+    out=$(echo "$payload23" | CLAUDE_WATCHDOG_LOG="$log23" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "BLOCK" ] || { cat "$log23"; fail "bg-tasks-optout-exit" "expected BLOCK got $outcome (opt-out should let it fire)"; }
+    if grep -q "background task(s) in flight" "$log23"; then fail "bg-tasks-optout-no-skip" "must not skip when opted out"; fi
+    cleanup_session "$sid23"
+    pass "background-tasks-opt-out"
+
+    # --- Test 24: session cron already scheduled for the analyzer -> SKIP ---
+    sid24="cursor-t24-$$"
+    cleanup_session "$sid24"
+    log24="$TMPROOT/log-t24"
+    payload24=$(jq -n --arg sid "$sid24" --arg tp "$t18_transcript" --arg cwd "$PWD" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", session_crons:[{prompt:"/loop /analyze-session"}]}')
+    rc=0
+    out=$(echo "$payload24" | CLAUDE_WATCHDOG_LOG="$log24" CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 node hooks/session-analysis.mjs 2>/dev/null) || rc=$?
+    outcome=$(hook_outcome "$out" "$rc")
+    [ "$outcome" = "SKIP" ] || { cat "$log24"; fail "session-cron-skip-exit" "expected SKIP got $outcome"; }
+    grep -q "SKIP: analysis already scheduled via session cron" "$log24" || { cat "$log24"; fail "session-cron-skip-log" "no session-cron skip log"; }
+    [ ! -f "$WATCHDOG_DIR/condensed-${sid24}.txt" ] || fail "session-cron-no-condensed" "condensed file should not exist"
+    cleanup_session "$sid24"
     pass "session-cron-skip"
 
     echo "--- all cursor tests passed ---"


### PR DESCRIPTION
## Problem (shipped in #8)

The merged guard skips whenever `stop_hook_active === true`, regardless of *which* Stop hook caused the continuation. A co-installed per-turn blocker (e.g. a "run tests before stop" plugin) makes **every** continuation carry the flag → the watchdog silently never fires for that user.

`stop_hook_active` is a **global** flag, not per-hook — confirmed against the Claude Code hooks docs (it is set for *all* Stop hooks once *any* hook blocks). So keying purely on it is too broad.

## Fix — one-shot self-owned sentinel

We only suppress the continuation that follows **our own** block:

- We drop `echo-<sid>` in `GLOBAL_SESSIONS_DIR` whenever we block (trigger the analyzer).
- We skip only when a Stop carries **both** `stop_hook_active === true` **and** our sentinel — proof the prior block was ours — then consume (delete) the sentinel.
- A **foreign** continuation (flag set, no sentinel) falls through to the existing cooldown / cursor / `MIN_TOOL_USES` gates and still fires.
- A **stale** sentinel on a fresh `end_turn` (chain ended, user did new work) is cleared rather than honored.

The sentinel lives in `GLOBAL_SESSIONS_DIR` (created early, before the local/global `SESSIONS_DIR` decision) so it resolves identically on the block turn and the echo turn regardless of `LOCAL_STORAGE`. The write is **best-effort**: if it ever fails, cooldown + cursor + `MIN_TOOL_USES` still gate the echo. `echo-<sid>` is reaped by the existing 2h TTL sweep.

## Why this is strictly better than #8

- **Single-Stop-hook users**: behave identically to #8 — our echo always carries the sentinel.
- **Multi-hook users**: no longer silently suppressed.
- **Degrades gracefully**: empirically verified that the hook still triggers even when the sentinel write is sabotaged.

## Tests (`justfile`, `test-cursor`)

- **Test 18** rewritten → full echo cycle: Phase 1 (substantial delta, `stop_hook_active:false`) asserts `TRIGGER:` and that `echo-<sid>` now exists; Phase 2 (same sid, `stop_hook_active:true`) asserts `SKIP: our own analyzer echo`, no `TRIGGER:`, and `echo-<sid>` removed.
- **Test 19** (new) — foreign continuation must still fire: fresh sid, no sentinel, `stop_hook_active:true`, substantial delta → asserts `TRIGGER:` and no echo-skip log. (Under #8 this would have wrongly skipped.)
- **Test 20** (new) — stale sentinel + fresh turn: pre-seed `echo-<sid>`, run with `stop_hook_active:false` + substantial delta → asserts `ECHO: stale sentinel cleared` and `TRIGGER:`. (The TRIGGER re-writes a fresh sentinel, so the test asserts the stale *content* is gone rather than file-absence.)

`cleanup_session` and the smoke trap also reap the global `echo-<sid>`.

## Sandbox note

The sentinel targets `GLOBAL_SESSIONS_DIR`, which is **not a new write surface**: the hook already unconditionally `mkdirSync`+`chmodSync`'s that dir at startup and always writes its debug log under `$HOME/.claude/logs/`, so global writability was already a hard dependency. `LOCAL_STORAGE` exists only to relocate the *condensed transcript* (which a subagent must `Read`, to avoid `auto`-mode Read prompts) — the sentinel is never `Read`.

## Docs

README "When does the hook actually fire?" bullet refined: *"This Stop is not the watchdog's own analyzer echo (tracked via a per-session sentinel) — continuations triggered by other plugins' Stop hooks are not suppressed."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)