### PR TITLE
fix: use namespaced subagent_type for session-analyzer in Stop hook

### DIFF
--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -450,7 +450,7 @@ Then stop.`;
   const instruction = `Please spawn a session-analyzer agent to critically analyze this session.
 
 Use the Agent tool with:
-- subagent_type: "session-analyzer"
+- subagent_type: "claude-watchdog:session-analyzer"
 - model: "sonnet"
 - prompt: "Read and analyze the condensed session transcript at '${safeCondensed}'. The working directory is '${safeCwd}'. Provide your critical analysis."
 


### PR DESCRIPTION
## Problem

The Stop-hook instruction (`hooks/session-analysis.mjs`) asks the user to spawn the analyzer with:

```
- subagent_type: "session-analyzer"
```

But the agent (`agents/session-analyzer.md`) is registered under the plugin namespace, so the Agent tool only resolves it as `claude-watchdog:session-analyzer`. The bare name fails on the first call **every session** with:

```
Agent type 'session-analyzer' not found. Available agents: ..., claude-watchdog:session-analyzer, ...
```

The model recovers by self-correcting to the namespaced form, so the analysis still runs — but it burns a wasted tool call and an error round-trip on every single Stop.

## Fix

Hardcode the namespaced name in the instruction template. The plugin name (`claude-watchdog`, per `.claude-plugin/plugin.json`) is fixed, so `claude-watchdog:session-analyzer` is stable.

```diff
-- subagent_type: "session-analyzer"
+- subagent_type: "claude-watchdog:session-analyzer"
```

One-line change; the descriptive prose ("spawn a session-analyzer agent") is left as-is since only the `subagent_type` value is matched by the Agent tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)