### PR TITLE
fix: keep mid-turn user messages in the condensed transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Run a short session and end Claude's turn. You should see output like:
 | Component | Path | Purpose |
 | --- | --- | --- |
 | Stop hook | `hooks/session-analysis.mjs` | Preprocesses the transcript, triggers the analyzer |
+| Condenser | `hooks/condense.mjs` | Turns the raw JSONL into the condensed transcript, within a byte budget |
 | SubagentStop hook | `hooks/persist-analysis.mjs` | Persists the analyzer's output to disk (no UI noise) |
 | UserPromptSubmit hook | `hooks/hold-input.mjs` | Optionally holds new prompts while an analysis is in flight |
 | Subagent | `agents/session-analyzer.md` | Reads the transcript + `git diff`, writes the review |
@@ -167,10 +168,26 @@ Don't want to wait for Claude to stop? Run `/analyze-session` any time during a 
 
 1. Claude Code fires the `Stop` hook when a turn ends.
 2. `session-analysis.mjs` receives the event JSON (session id, transcript path, cwd, stop reason) on stdin.
-3. It filters the JSONL transcript down to user text, assistant text, tool calls, and tool results, keeps the last ~50 KB, and writes it to `${CLAUDE_PLUGIN_DATA}/sessions/condensed-<session-id>.txt` (owner-only permissions; falls back to `~/.claude/tmp/claude-watchdog/sessions/` when not running as an installed plugin). When **Store transcripts in project directory** is enabled, files are written to `<project>/.claude/tmp/claude-watchdog/sessions/` instead — this keeps them inside the project directory so Claude Code's `auto` mode doesn't prompt for Read permission. Files older than 2 hours are cleaned up automatically in both locations.
+3. `condense.mjs` filters the JSONL transcript down to user text, assistant text, tool calls, and tool results, keeps the last ~50 KB, and writes it to `${CLAUDE_PLUGIN_DATA}/sessions/condensed-<session-id>.txt` (owner-only permissions; falls back to `~/.claude/tmp/claude-watchdog/sessions/` when not running as an installed plugin). When **Store transcripts in project directory** is enabled, files are written to `<project>/.claude/tmp/claude-watchdog/sessions/` instead — this keeps them inside the project directory so Claude Code's `auto` mode doesn't prompt for Read permission. The project directory is the nearest ancestor of the session's cwd holding `.git` or `.claude`, so a turn that ends with the shell inside a subdirectory still writes to one place per project. Files older than 2 hours are cleaned up automatically in both locations.
 4. It exits with code `2` and a stderr message instructing Claude to spawn the `session-analyzer` subagent pointed at that file.
 5. The subagent reads the condensed transcript, runs `git diff` / `git log` in the working directory, and produces the structured review — all inside your current Claude Code session, using the model you're already authenticated with.
 6. When the subagent finishes, Claude Code fires the `SubagentStop` hook. `persist-analysis.mjs` reads the subagent's final message from the event payload and writes it to `~/.claude/logs/claude-watchdog-analyses/` — so the subagent itself doesn't have to call `Write`, keeping the UI clean.
+
+### What the condensed transcript looks like
+
+One line per event, prefixed with its kind:
+
+| Prefix | Meaning |
+| --- | --- |
+| `USER:` | A prompt that started a turn |
+| `USER (mid-turn):` | A message typed while Claude was still working (Claude Code queues it, then injects it into the running turn). Authoritative user input — the analyzer weighs it the same as `USER:` |
+| `USER (mid-turn, origin=…):` | A queued prompt injected by automation (a cron, a hook) rather than by a person |
+| `USER (edited file):` | A file the user edited by hand during the session |
+| `ASSISTANT:` / `THINKING:` | Claude's replies and reasoning |
+| `TOOL_USE:` / `TOOL_RESULT:` | Tool calls and their results, truncated to 500 chars; `[ERROR]` marks failures |
+| `SYSTEM[…]:` | Everything else, including hook blocks and entry types the condenser doesn't know about |
+
+Pure session bookkeeping (window titles, PR links, mode pings, the last-prompt cache, queue enqueue/dequeue records) is dropped — it duplicates real message entries and otherwise crowds real content out of the byte budget. When the transcript busts the budget, user messages are kept ahead of tool traffic, and both ends of the user thread are kept (the opening goal and the most recent asks) rather than only the beginning.
 
 No data leaves your machine except through Claude Code's normal model calls.
 

--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -16,6 +16,10 @@ You are a critical session analyst. You will be given a condensed transcript fil
 
 Your workflow:
 1. Read the condensed transcript file to understand what was discussed, what tools were used (TOOL_USE lines show tool name and inputs), and what results they produced (TOOL_RESULT lines, with [ERROR] marking failures)
+   - `USER (mid-turn):` lines are messages the user typed while Claude was still working. They are authoritative user input - weigh them exactly as you would a `USER:` line. Work that traces back to one of them was requested, not self-directed, so never call it unrequested or unapproved scope expansion.
+   - `USER (mid-turn, origin=...):` lines were injected by something other than the person at the keyboard (a cron, a hook). Treat those as automation, not as a user ask.
+   - `USER (edited file):` lines mean the user edited that file by hand during the session.
+   - When the transcript is truncated it says so, and user messages may be elided in the middle. Absence of an instruction in a truncated transcript is not evidence the user never gave it - say "not visible in the transcript" rather than asserting the user did not ask.
 2. Run `git diff` and `git diff --cached` in the working directory to see what code was actually changed
 3. Run `git log --oneline -5` to see if any commits were made during the session
 4. Cross-reference the conversation goals against the actual code changes
@@ -32,7 +36,7 @@ Were there unnecessary detours, repeated failures, or wasted effort? Could the t
 Any concerns about the code, approaches, or information produced? Flag anything sloppy, hallucinated, or cargo-culted.
 
 ### Compliance
-Were any user instructions ignored or only partially followed? Were poor decisions made without flagging trade-offs? Were critical concerns raised by the user dismissed or handwaved away? Look for cases where Claude agreed too easily, skipped over risks, or failed to push back when it should have.
+Were any user instructions ignored or only partially followed? Were poor decisions made without flagging trade-offs? Were critical concerns raised by the user dismissed or handwaved away? Look for cases where Claude agreed too easily, skipped over risks, or failed to push back when it should have. Before flagging anything as unrequested, re-check the mid-turn user lines - that is where corrections and extra asks arrive.
 
 ### Recommendations
 1-3 specific, actionable items for follow-up or improvement. Format each as:

--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -19,7 +19,7 @@ Your workflow:
    - `USER (mid-turn):` lines are messages the user typed while Claude was still working. They are authoritative user input - weigh them exactly as you would a `USER:` line. Work that traces back to one of them was requested, not self-directed, so never call it unrequested or unapproved scope expansion.
    - `USER (mid-turn, origin=...):` lines were injected by something other than the person at the keyboard (a cron, a hook). Treat those as automation, not as a user ask.
    - `USER (edited file):` lines mean the user edited that file by hand during the session.
-   - When the transcript is truncated it says so, and user messages may be elided in the middle. Absence of an instruction in a truncated transcript is not evidence the user never gave it - say "not visible in the transcript" rather than asserting the user did not ask.
+   - A leading `[TRUNCATED]` line means content was dropped to fit a byte budget, and an `elided` marker in the user thread means user messages were cut from the middle. In either case, absence of an instruction is not evidence the user never gave it - say "not visible in the transcript" rather than asserting the user did not ask.
 2. Run `git diff` and `git diff --cached` in the working directory to see what code was actually changed
 3. Run `git log --oneline -5` to see if any commits were made during the session
 4. Cross-reference the conversation goals against the actual code changes

--- a/hooks/condense.mjs
+++ b/hooks/condense.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// Transcript extraction and byte-budget condensation for the Stop hook. Split out
+// of session-analysis.mjs so the fixture tests can exercise it directly
+// (`just test-condense`).
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const TOOL_RESULT_MAX = 500;
+const TOOL_INPUT_MAX = 500;
+const THINKING_MAX = 300;
+const SYSTEM_MAX = 200;
+
+// Bookkeeping entries whose payload is either duplicated by a real message entry
+// (last-prompt, queue enqueue/dequeue) or is UI-only (titles, PR links, mode
+// pings). Dumped as raw JSON they crowded out real content in the byte budget.
+// Unknown types are NOT dropped - they still fall through to a SYSTEM[...] line,
+// so a future type carrying user text degrades to noisy rather than invisible.
+const NOISE_TYPES = new Set(['last-prompt', 'custom-title', 'ai-title', 'pr-link', 'mode']);
+
+// Harness plumbing attachments - no session content worth spending budget on.
+const NOISE_ATTACHMENTS = new Set([
+  'task_reminder',
+  'deferred_tools_delta',
+  'agent_listing_delta',
+  'mcp_instructions_delta',
+  'skill_listing',
+]);
+
+// Some builds hand a mid-turn message to the model wrapped in framing text rather
+// than as a queued_command attachment. Strip the framing so the message reads as
+// the user's own words, and treat its presence as a mid-turn signal.
+const MIDTURN_FRAMING = /^\s*\[?\s*The user sent (?:a |an |another )?new message while you were working:?\s*\]?\s*/i;
+
+// Protected in the truncation path: every USER line, including the parenthesised
+// variants (mid-turn, edited file).
+export const USER_LINE = /^USER(?: \([^)]*\))?: /;
+export const MIDTURN_LINE = /^USER \(mid-turn/;
+
+const MIDTURN_LABEL = 'USER (mid-turn)';
+const ELISION = '--- [earlier user messages elided] ---';
+
+function parseLines(lines) {
+  const out = [];
+  for (const line of lines) {
+    if (!line || line[0] !== '{') continue;
+    try { out.push(JSON.parse(line)); } catch { /* skip malformed lines */ }
+  }
+  return out;
+}
+
+function queuedPrompt(att) {
+  const raw = typeof att?.prompt === 'string' ? att.prompt
+    : typeof att?.content === 'string' ? att.content
+      : '';
+  return raw.trim();
+}
+
+// A queued prompt can be injected by something other than the person at the
+// keyboard (a cron, a hook). Keep it visible but don't let it pass as a human ask.
+function midTurnLabel(origin) {
+  return origin && origin !== 'human' ? `USER (mid-turn, origin=${origin})` : MIDTURN_LABEL;
+}
+
+function toolResultText(block) {
+  if (typeof block.content === 'string') return block.content.slice(0, TOOL_RESULT_MAX);
+  if (Array.isArray(block.content)) {
+    return block.content
+      .filter(c => c.type === 'text')
+      .map(c => c.text)
+      .join('\n')
+      .slice(0, TOOL_RESULT_MAX);
+  }
+  return '(no content)';
+}
+
+export function extractTranscript(lines) {
+  const entries = parseLines(lines);
+  const output = [];
+
+  // Mid-turn input reaches the transcript as an attachment (attachment.type
+  // 'queued_command', text in attachment.prompt). A `queue-operation` with
+  // operation 'remove' carries the same text a line earlier - the same event seen
+  // from the queue's side. Collect the attachment prompts first so the
+  // queue-operation path below is only a fallback for builds that don't log the
+  // attachment, rather than a source of duplicates.
+  const attachmentPrompts = new Set();
+  for (const obj of entries) {
+    if (obj.type === 'attachment' && obj.attachment?.type === 'queued_command') {
+      const prompt = queuedPrompt(obj.attachment);
+      if (prompt) attachmentPrompts.add(prompt);
+    }
+  }
+
+  for (const obj of entries) {
+    if (obj.type === 'user') {
+      const content = obj.message?.content;
+      if (typeof content === 'string') {
+        const framed = MIDTURN_FRAMING.test(content);
+        output.push(`${framed ? MIDTURN_LABEL : 'USER'}: ${content.replace(MIDTURN_FRAMING, '')}`);
+      } else if (Array.isArray(content)) {
+        // Text sharing an entry with tool_result blocks was typed while the turn
+        // was still running - it is not the prompt that started the turn.
+        const midTurn = content.some(b => b.type === 'tool_result');
+        for (const block of content) {
+          if (block.type === 'text') {
+            const text = block.text || '';
+            const label = (midTurn || MIDTURN_FRAMING.test(text)) ? MIDTURN_LABEL : 'USER';
+            output.push(`${label}: ${text.replace(MIDTURN_FRAMING, '')}`);
+          } else if (block.type === 'tool_result') {
+            output.push(`TOOL_RESULT: ${toolResultText(block)}${block.is_error === true ? ' [ERROR]' : ''}`);
+          }
+        }
+      }
+    } else if (obj.type === 'assistant') {
+      const blocks = obj.message?.content;
+      if (Array.isArray(blocks)) {
+        for (const block of blocks) {
+          if (block.type === 'text') {
+            output.push(`ASSISTANT: ${block.text}`);
+          } else if (block.type === 'thinking') {
+            output.push(`THINKING: ${(block.thinking || '').slice(0, THINKING_MAX)}`);
+          } else if (block.type === 'tool_use') {
+            output.push(`TOOL_USE: ${block.name}(${JSON.stringify(block.input).slice(0, TOOL_INPUT_MAX)})`);
+          }
+        }
+      }
+    } else if (obj.type === 'attachment') {
+      const att = obj.attachment || {};
+      if (att.type === 'queued_command') {
+        const prompt = queuedPrompt(att);
+        if (prompt) output.push(`${midTurnLabel(att.origin?.kind)}: ${prompt}`);
+      } else if (att.type === 'edited_text_file') {
+        // The user edited a file by hand mid-session. The snippet is large and
+        // the diff shows the content anyway; the filename is the signal.
+        output.push(`USER (edited file): ${att.filename || '(unknown)'}`);
+      } else if (att.type === 'hook_blocking_error') {
+        const err = att.blockingError?.blockingError ?? att.blockingError ?? '';
+        output.push(`SYSTEM[hook-blocked ${att.hookName || att.hookEvent || 'hook'}]: ${String(err).slice(0, SYSTEM_MAX)}`);
+      } else if (att.type === 'plan_mode' || att.type === 'plan_mode_exit') {
+        output.push(`SYSTEM[${att.type}]`);
+      } else if (!NOISE_ATTACHMENTS.has(att.type)) {
+        output.push(`SYSTEM[attachment:${att.type || 'unknown'}]: ${JSON.stringify(att).slice(0, SYSTEM_MAX)}`);
+      }
+    } else if (obj.type === 'queue-operation') {
+      // 'remove' means the queued prompt was pulled out and injected into the
+      // running turn; 'dequeue' means it became the next turn's own user message
+      // (already captured as a user entry above). Fall back to this record only
+      // when the authoritative queued_command attachment is absent from the slice.
+      const content = (obj.content || '').trim();
+      if (obj.operation === 'remove' && content && !attachmentPrompts.has(content)) {
+        output.push(`${MIDTURN_LABEL}: ${content}`);
+      }
+    } else if (!NOISE_TYPES.has(obj.type)) {
+      output.push(`SYSTEM[${obj.type || 'unknown'}]: ${JSON.stringify(obj).slice(0, SYSTEM_MAX)}`);
+    }
+  }
+
+  return output.join('\n');
+}
+
+// Accumulate whole lines from one end until the byte budget is spent. Line-wise
+// rather than Buffer.slice so a cut can't land mid-line or split a UTF-8 char.
+function takeLines(lines, budget, from) {
+  const seq = from === 'tail' ? [...lines].reverse() : lines;
+  const picked = [];
+  let used = 0;
+  for (const line of seq) {
+    const cost = Buffer.byteLength(line, 'utf8') + 1;
+    if (used + cost > budget) break;
+    picked.push(line);
+    used += cost;
+  }
+  return { lines: from === 'tail' ? picked.reverse() : picked, used };
+}
+
+// Keep both ends of the user thread. The head carries the session goal, the tail
+// carries the most recent asks - which is where mid-turn corrections land. Taking
+// only the head (the previous behaviour) silently dropped late user input on long
+// sessions.
+function clampUserLines(userLines, budget) {
+  const size = Buffer.byteLength(userLines.join('\n'), 'utf8');
+  if (size <= budget) return userLines;
+
+  const room = Math.max(0, budget - Buffer.byteLength(ELISION, 'utf8') - 1);
+  const head = takeLines(userLines, Math.floor(room * 0.4), 'head');
+  const tail = takeLines(userLines.slice(head.lines.length), room - head.used, 'tail');
+  return [...head.lines, ELISION, ...tail.lines];
+}
+
+export function condense(rawContent, maxBytes) {
+  const rawSize = Buffer.byteLength(rawContent, 'utf8');
+  if (rawSize <= maxBytes) return { content: rawContent, rawSize, truncated: false, droppedKb: 0 };
+
+  const rawLines = rawContent.split('\n');
+  const userLines = rawLines.filter(l => USER_LINE.test(l));
+  const otherLines = rawLines.filter(l => !USER_LINE.test(l));
+
+  const userPart = clampUserLines(userLines, Math.floor(maxBytes / 5)).join('\n');
+  const otherPart = takeLines(otherLines, Math.floor(maxBytes * 4 / 5), 'tail').lines.join('\n');
+
+  const content = [
+    userPart,
+    '',
+    '--- [above: user messages in order, mid-turn ones labelled; below: recent tool calls and responses] ---',
+    '',
+    otherPart,
+  ].join('\n');
+
+  return { content, rawSize, truncated: true, droppedKb: Math.floor((rawSize - maxBytes) / 1024) };
+}
+
+export function counts(content) {
+  const lines = content.split('\n');
+  return {
+    user: lines.filter(l => USER_LINE.test(l)).length,
+    midTurn: lines.filter(l => MIDTURN_LINE.test(l)).length,
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [, , cmd, ...args] = process.argv;
+  try {
+    if (cmd === 'extract') {
+      process.stdout.write(extractTranscript(readFileSync(args[0], 'utf8').split('\n')) + '\n');
+      process.exit(0);
+    } else if (cmd === 'condense') {
+      const raw = extractTranscript(readFileSync(args[0], 'utf8').split('\n'));
+      process.stdout.write(condense(raw, parseInt(args[1] ?? '51200', 10)).content + '\n');
+      process.exit(0);
+    } else {
+      process.stderr.write('usage: condense.mjs extract <transcript.jsonl> | condense <transcript.jsonl> [maxBytes]\n');
+      process.exit(2);
+    }
+  } catch (e) {
+    process.stderr.write(`condense error: ${e.message}\n`);
+    process.exit(1);
+  }
+}

--- a/hooks/condense.mjs
+++ b/hooks/condense.mjs
@@ -198,7 +198,14 @@ export function condense(rawContent, maxBytes) {
   const userPart = clampUserLines(userLines, Math.floor(maxBytes / 5)).join('\n');
   const otherPart = takeLines(otherLines, Math.floor(maxBytes * 4 / 5), 'tail').lines.join('\n');
 
+  const droppedKb = Math.floor((rawSize - maxBytes) / 1024);
+
+  // The notice is unconditional, not verbose-only: without it a truncated file
+  // reads to the analyzer as a session that ended early, and it cannot tell that a
+  // missing instruction was elided rather than never given.
   const content = [
+    `[TRUNCATED] Original transcript was ${rawSize} bytes (~${droppedKb}KB dropped). Early context may be incomplete.`,
+    '',
     userPart,
     '',
     '--- [above: user messages in order, mid-turn ones labelled; below: recent tool calls and responses] ---',
@@ -206,7 +213,7 @@ export function condense(rawContent, maxBytes) {
     otherPart,
   ].join('\n');
 
-  return { content, rawSize, truncated: true, droppedKb: Math.floor((rawSize - maxBytes) / 1024) };
+  return { content, rawSize, truncated: true, droppedKb };
 }
 
 export function counts(content) {

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -361,12 +361,9 @@ try {
   const verbose = cfg('CLAUDE_WATCHDOG_VERBOSE', 'CLAUDE_PLUGIN_OPTION_VERBOSE', '0');
   const isVerbose = verbose === '1' || verbose === 'true';
 
-  const { content, rawSize, truncated, droppedKb } = condense(rawContent, CONDENSED_MAX_BYTES);
+  // condense() prepends its own [TRUNCATED] notice when it trims, unconditionally.
+  const { content, rawSize } = condense(rawContent, CONDENSED_MAX_BYTES);
   let condensedContent = content;
-
-  if (isVerbose && truncated) {
-    condensedContent = `[TRUNCATED] Original transcript was ${rawSize} bytes (~${droppedKb}KB dropped). Early context may be incomplete.\n\n${condensedContent}`;
-  }
 
   if (isVerbose) {
     const { user, midTurn } = counts(condensedContent);

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -3,9 +3,10 @@ import {
   readFileSync, writeFileSync, appendFileSync, mkdirSync, readdirSync,
   statSync, unlinkSync, rmdirSync, existsSync, chmodSync
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, parse as parsePath, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { slice, lastUuid } from './cursor-slice.mjs';
+import { extractTranscript, condense, counts } from './condense.mjs';
 
 function cfg(watchdogVar, pluginVar, defaultVal) {
   return process.env[watchdogVar] ?? process.env[pluginVar] ?? defaultVal;
@@ -91,56 +92,29 @@ function truncateStrings(val, max) {
   return val;
 }
 
-function extractTranscript(lines) {
-  const output = [];
-  for (const line of lines) {
-    if (!line || line[0] !== '{') continue;
-    let obj;
-    try { obj = JSON.parse(line); } catch { continue; }
-
-    if (obj.type === 'user') {
-      const content = obj.message?.content;
-      if (typeof content === 'string') {
-        output.push(`USER: ${content}`);
-      } else if (Array.isArray(content)) {
-        for (const block of content) {
-          if (block.type === 'text') {
-            output.push(`USER: ${block.text}`);
-          } else if (block.type === 'tool_result') {
-            let text;
-            if (typeof block.content === 'string') {
-              text = block.content.slice(0, 500);
-            } else if (Array.isArray(block.content)) {
-              text = block.content
-                .filter(c => c.type === 'text')
-                .map(c => c.text)
-                .join('\n')
-                .slice(0, 500);
-            } else {
-              text = '(no content)';
-            }
-            output.push(`TOOL_RESULT: ${text}${block.is_error === true ? ' [ERROR]' : ''}`);
-          }
-        }
-      }
-    } else if (obj.type === 'assistant') {
-      const blocks = obj.message?.content;
-      if (Array.isArray(blocks)) {
-        for (const block of blocks) {
-          if (block.type === 'text') {
-            output.push(`ASSISTANT: ${block.text}`);
-          } else if (block.type === 'thinking') {
-            output.push(`THINKING: ${(block.thinking || '').slice(0, 300)}`);
-          } else if (block.type === 'tool_use') {
-            output.push(`TOOL_USE: ${block.name}(${JSON.stringify(block.input).slice(0, 500)})`);
-          }
-        }
-      }
-    } else {
-      output.push(`SYSTEM[${obj.type || 'unknown'}]: ${JSON.stringify(obj).slice(0, 200)}`);
-    }
+// Anchor project-local storage to the project root, not the shell's cwd at stop
+// time. A turn that ended with the shell inside a subdirectory used to scatter
+// condensed transcripts (and the delta cursor) into <repo>/<subdir>/.claude/tmp,
+// splitting one session's state across paths. The walk stops below $HOME so a
+// marker in the home directory can't hoist every project to the same place, and
+// returns startDir unchanged when nothing is found, preserving the old behaviour.
+function projectRoot(startDir) {
+  const home = resolve(homedir());
+  const start = resolve(startDir);
+  const { root } = parsePath(start);
+  let dir = start;
+  let claudeDir = null;
+  while (dir !== root && dir !== home) {
+    // .git decides the root. .claude is a weaker signal - it may be a stray
+    // directory an earlier run left in a subdirectory, which would otherwise keep
+    // re-anchoring there - so it only wins when there is no .git above at all.
+    if (existsSync(join(dir, '.git'))) return dir;
+    if (!claudeDir && existsSync(join(dir, '.claude'))) claudeDir = dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
-  return output.join('\n');
+  return claudeDir ?? start;
 }
 
 function countToolUses(lines) {
@@ -288,7 +262,9 @@ try {
   let SESSIONS_DIR = GLOBAL_SESSIONS_DIR;
   if (LOCAL_STORAGE === '1' || LOCAL_STORAGE === 'true') {
     if (hookCwd && hookCwd !== 'null' && existsSync(hookCwd)) {
-      const localDir = join(hookCwd, '.claude/tmp/claude-watchdog/sessions');
+      const rootDir = projectRoot(hookCwd);
+      if (rootDir !== resolve(hookCwd)) log(`LOCAL_STORAGE: anchored to project root ${rootDir} (cwd was ${hookCwd})`);
+      const localDir = join(rootDir, '.claude/tmp/claude-watchdog/sessions');
       try {
         mkdirSync(localDir, { recursive: true });
         chmodSync(localDir, 0o700);
@@ -382,45 +358,20 @@ try {
   const CONDENSED_FILE = join(SESSIONS_DIR, `condensed-${sessionId}.txt`);
 
   const rawContent = extractTranscript(deltaLines);
-  const rawSize = Buffer.byteLength(rawContent, 'utf8');
   const verbose = cfg('CLAUDE_WATCHDOG_VERBOSE', 'CLAUDE_PLUGIN_OPTION_VERBOSE', '0');
   const isVerbose = verbose === '1' || verbose === 'true';
 
-  let condensedContent;
-  if (rawSize <= CONDENSED_MAX_BYTES) {
-    condensedContent = rawContent;
-  } else {
-    const rawLines = rawContent.split('\n');
-    const userLines = rawLines.filter(l => l.startsWith('USER: '));
-    const otherLines = rawLines.filter(l => !l.startsWith('USER: '));
+  const { content, rawSize, truncated, droppedKb } = condense(rawContent, CONDENSED_MAX_BYTES);
+  let condensedContent = content;
 
-    const USER_BUDGET = Math.floor(CONDENSED_MAX_BYTES / 5);
-    const OTHER_BUDGET = Math.floor(CONDENSED_MAX_BYTES * 4 / 5);
-    const droppedKb = Math.floor((rawSize - CONDENSED_MAX_BYTES) / 1024);
-
-    const userBuf = Buffer.from(userLines.join('\n'), 'utf8');
-    const otherBuf = Buffer.from(otherLines.join('\n'), 'utf8');
-
-    const userPart = userBuf.slice(0, USER_BUDGET).toString('utf8');
-    const otherPart = otherBuf.slice(-OTHER_BUDGET).toString('utf8');
-
-    const parts = [];
-    if (isVerbose) {
-      parts.push(`[TRUNCATED] Original transcript was ${rawSize} bytes (~${droppedKb}KB dropped). Early context may be incomplete.`);
-      parts.push('');
-    }
-    parts.push(userPart);
-    parts.push('');
-    parts.push('--- [above: user messages; below: recent tool calls and responses] ---');
-    parts.push('');
-    parts.push(otherPart);
-    condensedContent = parts.join('\n');
+  if (isVerbose && truncated) {
+    condensedContent = `[TRUNCATED] Original transcript was ${rawSize} bytes (~${droppedKb}KB dropped). Early context may be incomplete.\n\n${condensedContent}`;
   }
 
   if (isVerbose) {
-    const userMsgCount = condensedContent.split('\n').filter(l => l.startsWith('USER: ')).length;
+    const { user, midTurn } = counts(condensedContent);
     const condensedSize = Buffer.byteLength(condensedContent, 'utf8');
-    condensedContent = `[DIAGNOSTICS] raw=${rawSize}B condensed=${condensedSize}B tool_uses=${toolUseCount} user_messages=${userMsgCount} delta_start=${deltaStart}\n\n${condensedContent}`;
+    condensedContent = `[DIAGNOSTICS] raw=${rawSize}B condensed=${condensedSize}B tool_uses=${toolUseCount} user_messages=${user} mid_turn_messages=${midTurn} delta_start=${deltaStart}\n\n${condensedContent}`;
   }
 
   if (!condensedContent || condensedContent.trim().length === 0) {

--- a/justfile
+++ b/justfile
@@ -752,6 +752,9 @@ test-condense:
     clamped="$TMPROOT/clamped.txt"
     node hooks/condense.mjs condense "$many" 8192 > "$clamped"
     grep -q 'elided' "$clamped" || { head -5 "$clamped"; fail "clamp-marker" "expected an elision marker"; }
+    # The truncation notice must reach the analyzer with verbose off (the default),
+    # or a truncated transcript reads as a session that ended early.
+    grep -q '^\[TRUNCATED\]' "$clamped" || { head -3 "$clamped"; fail "clamp-notice" "no [TRUNCATED] notice without verbose mode"; }
     grep -q '^USER: ask number 1 - ' "$clamped" || fail "clamp-head" "first user message (session goal) dropped"
     grep -q '^USER: ask number 300 - ' "$clamped" || fail "clamp-tail" "last user message dropped - head-only slice regressed"
     pass "user-clamp-keeps-both-ends"

--- a/justfile
+++ b/justfile
@@ -10,7 +10,9 @@ lint:
     node --check hooks/session-analysis.mjs
     node --check hooks/persist-analysis.mjs
     node --check hooks/cursor-slice.mjs
+    node --check hooks/condense.mjs
     node --check hooks/hold-input.mjs
+    for f in tests/fixtures/*.jsonl; do node -e 'const p=process.argv[1]; require("fs").readFileSync(p,"utf8").split("\n").forEach((s,i)=>{ if(!s.startsWith("{")) return; try { JSON.parse(s) } catch (e) { console.error(`${p}:${i+1}: ${e.message}`); process.exit(1) } })' "$f"; done
 
 # Smoke-test the hook with a synthetic Stop event
 smoke:
@@ -643,6 +645,195 @@ test-persist:
 
     echo "--- all persist tests passed ---"
 
+# Transcript condensation: mid-turn user input, noise filtering, byte budget,
+# project-root anchoring. Fixture is sanitised from a real session that lost four
+# mid-turn user messages (see tests/fixtures/midturn-session.jsonl).
+test-condense:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TMPROOT=$(mktemp -d)
+    trap 'rm -rf "$TMPROOT"' EXIT
+
+    pass() { echo "PASS: $1"; }
+    fail() { echo "FAIL: $1 - $2" >&2; exit 1; }
+
+    FIXTURE="tests/fixtures/midturn-session.jsonl"
+    out="$TMPROOT/extracted.txt"
+    node hooks/condense.mjs extract "$FIXTURE" > "$out"
+
+    # count_fixed <literal> -> number of lines containing it
+    count_fixed() { grep -cF "$1" "$out" || true; }
+
+    # --- Test 1: every mid-turn user message survives, labelled, exactly once ---
+    # These four are verbatim from the session that regressed. Each arrives in a
+    # different encoding: queue-operation + attachment, attachment only, and
+    # queue-operation 'remove' with no attachment.
+    MIDTURN_MSGS=(
+      'You can check ../base-infrastructure-for-services for any permission changes needed.'
+      'Also - please base the changes on _recent_ additions, it looks like the GHA stuff is circa 2022.'
+      'Can you please rename stack components to the more generic `bre-remote-cache`?'
+      'Also - please compare to other BIFS services within the same repo'
+    )
+    for msg in "${MIDTURN_MSGS[@]}"; do
+      n=$(count_fixed "$msg")
+      [ "$n" = "1" ] || { cat "$out"; fail "midturn-present" "expected 1 line containing '$msg', got $n"; }
+      grep -F "$msg" "$out" | grep -q "^USER (mid-turn): ${msg:0:12}" || { cat "$out"; fail "midturn-label" "'$msg' not labelled USER (mid-turn) from the start of the message"; }
+    done
+    pass "midturn-messages-extracted"
+
+    # --- Test 2: text interleaved with tool_result in one user entry is mid-turn ---
+    grep -qF 'USER (mid-turn): Hold on - use the leaner shape' "$out" || fail "midturn-array" "interleaved text block not labelled mid-turn"
+    pass "midturn-array-content"
+
+    # --- Test 3: system framing is recognised and stripped ---
+    grep -qxF 'USER (mid-turn): Skip the GHA workflow entirely.' "$out" || { cat "$out"; fail "midturn-framing" "framed message not unwrapped"; }
+    if grep -q 'sent a new message while you were working' "$out"; then fail "midturn-framing-strip" "framing text leaked into output"; fi
+    pass "midturn-framing-stripped"
+
+    # --- Test 4: non-human queued prompts are labelled, not passed off as user asks ---
+    grep -qF 'USER (mid-turn, origin=cron): Scheduled follow-up' "$out" || fail "midturn-origin" "cron-origin prompt not marked"
+    pass "midturn-origin-labelled"
+
+    # --- Test 5: a queued prompt that became its own turn appears once, not mid-turn ---
+    n=$(count_fixed "Merged 6272. Can you inspect the comments on 877?")
+    [ "$n" = "1" ] || fail "dequeued-once" "dequeued prompt should appear once, got $n"
+    grep -qxF 'USER: Merged 6272. Can you inspect the comments on 877?' "$out" || fail "dequeued-plain" "dequeued prompt should be a plain USER line"
+    pass "dequeued-prompt-not-duplicated"
+
+    # --- Test 6: manual file edits surface as user action ---
+    grep -qxF 'USER (edited file): /repo/MAINTENANCE.md' "$out" || fail "edited-file" "edited_text_file not surfaced"
+    if grep -q '# Maintenance' "$out"; then fail "edited-file-snippet" "edited_text_file snippet should not be inlined"; fi
+    pass "edited-file-surfaced"
+
+    # --- Test 7: bookkeeping entries no longer spend budget ---
+    for noise in 'last-prompt' 'custom-title' 'ai-title' 'pr-link' 'SYSTEM[mode]' 'task_reminder'; do
+      if grep -qF "$noise" "$out"; then cat "$out"; fail "noise-dropped" "bookkeeping entry '$noise' still emitted"; fi
+    done
+    pass "bookkeeping-noise-dropped"
+
+    # --- Test 8: unknown entry types stay visible (a future user-bearing type must
+    # degrade to noisy, never to invisible) ---
+    grep -q 'SYSTEM\[totally-unknown-future-type\]' "$out" || fail "unknown-kept" "unknown entry type was dropped"
+    pass "unknown-type-retained"
+
+    # --- Test 9: tool_result noise is still condensed, errors still flagged ---
+    grep -q '^TOOL_RESULT: On branch feat/remote-cache$' "$out" || fail "tool-result-kept" "tool_result not condensed into a TOOL_RESULT line"
+    grep -q '^TOOL_RESULT: edit failed: file not found \[ERROR\]$' "$out" || fail "tool-result-error" "tool_result error flag lost"
+    pass "tool-result-condensing-intact"
+
+    # --- Test 10: under the byte budget, mid-turn lines survive tool-call flood ---
+    # Mirrors the real session's shape: ~400KB of tool traffic, a few KB of user text,
+    # 50KB budget. Mid-turn lines must land in the protected user bucket.
+    flood="$TMPROOT/flood.jsonl"
+    cat "$FIXTURE" > "$flood"
+    for i in $(seq 1 400); do
+      jq -nc --arg i "$i" '{type:"assistant",uuid:("a-f"+$i),message:{content:[{type:"tool_use",id:("tf_"+$i),name:"Read",input:{file_path:("/repo/file-"+$i+".tf"),padding:"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}]}}' >> "$flood"
+      jq -nc --arg i "$i" '{type:"user",uuid:("u-f"+$i),message:{content:[{type:"tool_result",tool_use_id:("tf_"+$i),content:("resource block "+$i+" xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")}]}}' >> "$flood"
+    done
+    budgeted="$TMPROOT/budgeted.txt"
+    node hooks/condense.mjs condense "$flood" 51200 > "$budgeted"
+    raw_bytes=$(node hooks/condense.mjs extract "$flood" | wc -c | tr -d ' ')
+    [ "$raw_bytes" -gt 51200 ] || fail "budget-precondition" "flood transcript ($raw_bytes B) did not exceed the budget"
+    [ "$(wc -c < "$budgeted" | tr -d ' ')" -le 52400 ] || fail "budget-respected" "condensed output exceeded the budget"
+    midturn=$(grep -c '^USER (mid-turn' "$budgeted" || true)
+    [ "$midturn" = "7" ] || fail "budget-midturn" "expected all 7 mid-turn lines to survive truncation, got $midturn"
+    grep -qF 'You can check ../base-infrastructure-for-services' "$budgeted" || fail "budget-midturn-text" "mid-turn text dropped by truncation"
+    pass "midturn-survives-byte-budget"
+
+    # --- Test 11: when user text alone busts its budget, both ends are kept ---
+    # The old head-only slice dropped the most recent asks - exactly where mid-turn
+    # corrections live.
+    many="$TMPROOT/many-users.jsonl"
+    : > "$many"
+    for i in $(seq 1 300); do
+      jq -nc --arg i "$i" '{type:"user",uuid:("u-m"+$i),message:{content:("ask number "+$i+" - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")}}' >> "$many"
+      jq -nc --arg i "$i" '{type:"assistant",uuid:("a-m"+$i),message:{content:[{type:"tool_use",id:("tm_"+$i),name:"Read",input:{file_path:("/repo/f"+$i)}}]}}' >> "$many"
+    done
+    clamped="$TMPROOT/clamped.txt"
+    node hooks/condense.mjs condense "$many" 8192 > "$clamped"
+    grep -q 'elided' "$clamped" || { head -5 "$clamped"; fail "clamp-marker" "expected an elision marker"; }
+    grep -q '^USER: ask number 1 - ' "$clamped" || fail "clamp-head" "first user message (session goal) dropped"
+    grep -q '^USER: ask number 300 - ' "$clamped" || fail "clamp-tail" "last user message dropped - head-only slice regressed"
+    pass "user-clamp-keeps-both-ends"
+
+    # --- Test 12: end-to-end through the Stop hook ---
+    e2e_sid="condense-e2e-$$"
+    e2e_tmp="$TMPROOT/wtmp"
+    e2e_cwd="$TMPROOT/e2e-project"
+    mkdir -p "$e2e_cwd"
+    payload=$(jq -n --arg sid "$e2e_sid" --arg tp "$FIXTURE" --arg cwd "$e2e_cwd" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    hook_out=$(echo "$payload" | CLAUDE_WATCHDOG_LOG="$TMPROOT/hook.log" CLAUDE_WATCHDOG_TMP="$e2e_tmp" \
+      CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=0 \
+      CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 CLAUDE_WATCHDOG_VERBOSE=1 \
+      node hooks/session-analysis.mjs 2>/dev/null)
+    echo "$hook_out" | grep -q '"decision":"block"' || { cat "$TMPROOT/hook.log"; fail "e2e-trigger" "hook did not trigger"; }
+    e2e_file="$e2e_tmp/sessions/condensed-${e2e_sid}.txt"
+    [ -f "$e2e_file" ] || fail "e2e-file" "condensed file not written"
+    grep -qF 'USER (mid-turn): You can check ../base-infrastructure-for-services' "$e2e_file" || { cat "$e2e_file"; fail "e2e-midturn" "mid-turn message missing from hook output"; }
+    grep -q 'mid_turn_messages=7' "$e2e_file" || { head -2 "$e2e_file"; fail "e2e-diagnostics" "verbose diagnostics missing the mid-turn count"; }
+    pass "end-to-end-hook-output"
+
+    # --- Test 13: local storage anchors to the project root, not the shell cwd ---
+    # A turn ending with the shell inside a subdirectory used to scatter transcripts
+    # into <repo>/<subdir>/.claude/tmp.
+    anchor_sid="condense-anchor-$$"
+    repo="$TMPROOT/fake-repo"
+    deep="$repo/services/remote-cache"
+    mkdir -p "$deep" "$repo/.git"
+    payload_a=$(jq -n --arg sid "$anchor_sid" --arg tp "$FIXTURE" --arg cwd "$deep" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    echo "$payload_a" | CLAUDE_WATCHDOG_LOG="$TMPROOT/anchor.log" CLAUDE_WATCHDOG_TMP="$TMPROOT/atmp" \
+      CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=1 \
+      CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 \
+      node hooks/session-analysis.mjs >/dev/null 2>&1
+    [ -f "$repo/.claude/tmp/claude-watchdog/sessions/condensed-${anchor_sid}.txt" ] || { cat "$TMPROOT/anchor.log"; fail "anchor-root" "condensed not written to the project root"; }
+    [ ! -d "$deep/.claude" ] || fail "anchor-subdir" "hook created .claude inside the subdirectory"
+    grep -q "LOCAL_STORAGE: anchored to project root" "$TMPROOT/anchor.log" || fail "anchor-log" "no anchoring log line"
+    pass "local-storage-anchors-to-project-root"
+
+    # --- Test 14: a stray .claude in a subdirectory does not re-anchor there ---
+    # The old bug left one behind; .git must still win, or the fix perpetuates it.
+    stray_sid="condense-stray-$$"
+    mkdir -p "$deep/.claude/tmp/claude-watchdog/sessions"
+    payload_s=$(jq -n --arg sid "$stray_sid" --arg tp "$FIXTURE" --arg cwd "$deep" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    echo "$payload_s" | CLAUDE_WATCHDOG_LOG="$TMPROOT/stray.log" CLAUDE_WATCHDOG_TMP="$TMPROOT/stmp" \
+      CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=1 \
+      CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 \
+      node hooks/session-analysis.mjs >/dev/null 2>&1
+    [ -f "$repo/.claude/tmp/claude-watchdog/sessions/condensed-${stray_sid}.txt" ] || { cat "$TMPROOT/stray.log"; fail "stray-claude-root" "did not anchor to the git root"; }
+    [ ! -f "$deep/.claude/tmp/claude-watchdog/sessions/condensed-${stray_sid}.txt" ] || fail "stray-claude-subdir" "re-anchored to the stray .claude directory"
+    pass "stray-claude-dir-does-not-win-over-git"
+
+    # --- Test 15: no .git, but a .claude marker -> anchor there ---
+    nogit_sid="condense-nogit-$$"
+    nogit="$TMPROOT/no-git-project"
+    mkdir -p "$nogit/.claude" "$nogit/nested/dir"
+    payload_n=$(jq -n --arg sid "$nogit_sid" --arg tp "$FIXTURE" --arg cwd "$nogit/nested/dir" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    echo "$payload_n" | CLAUDE_WATCHDOG_LOG="$TMPROOT/nogit.log" CLAUDE_WATCHDOG_TMP="$TMPROOT/ntmp" \
+      CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=1 \
+      CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 \
+      node hooks/session-analysis.mjs >/dev/null 2>&1
+    [ -f "$nogit/.claude/tmp/claude-watchdog/sessions/condensed-${nogit_sid}.txt" ] || { cat "$TMPROOT/nogit.log"; fail "nogit-claude" "did not anchor to the .claude marker"; }
+    pass "claude-marker-anchors-when-no-git"
+
+    # --- Test 16: no project marker -> cwd is used, as before ---
+    plain_sid="condense-plain-$$"
+    plain="$TMPROOT/no-markers/work"
+    mkdir -p "$plain"
+    payload_p=$(jq -n --arg sid "$plain_sid" --arg tp "$FIXTURE" --arg cwd "$plain" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    echo "$payload_p" | CLAUDE_WATCHDOG_LOG="$TMPROOT/plain.log" CLAUDE_WATCHDOG_TMP="$TMPROOT/ptmp" \
+      CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=1 \
+      CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 \
+      node hooks/session-analysis.mjs >/dev/null 2>&1
+    [ -f "$plain/.claude/tmp/claude-watchdog/sessions/condensed-${plain_sid}.txt" ] || { cat "$TMPROOT/plain.log"; fail "no-marker-cwd" "condensed not written under the cwd"; }
+    pass "no-marker-falls-back-to-cwd"
+
+    echo "--- all condense tests passed ---"
+
 # Test the UserPromptSubmit input-hold hook
 test-hold:
     #!/usr/bin/env bash
@@ -718,7 +909,7 @@ test-hold:
     echo "--- all hold tests passed ---"
 
 # Run all tests
-test: smoke test-cursor test-persist test-hold
+test: smoke test-cursor test-condense test-persist test-hold
 
 # Lint + all tests
 check: lint test

--- a/skills/analyze-session/SKILL.md
+++ b/skills/analyze-session/SKILL.md
@@ -27,7 +27,7 @@ Were there unnecessary detours, repeated failures, or wasted effort? Could the t
 Any concerns about the code, approaches, or information produced? Flag anything sloppy, hallucinated, or cargo-culted.
 
 ### Compliance
-Were any user instructions ignored or only partially followed? Were poor decisions made without flagging trade-offs? Were critical concerns raised by the user dismissed or handwaved away? Look for cases where Claude agreed too easily, skipped over risks, or failed to push back when it should have.
+Were any user instructions ignored or only partially followed? Were poor decisions made without flagging trade-offs? Were critical concerns raised by the user dismissed or handwaved away? Look for cases where Claude agreed too easily, skipped over risks, or failed to push back when it should have. Before flagging anything as unrequested, re-check for messages the user sent mid-turn while Claude was working - that is where corrections and extra asks arrive.
 
 ### Recommendations
 1-3 specific, actionable items for follow-up or improvement.

--- a/tests/fixtures/midturn-session.jsonl
+++ b/tests/fixtures/midturn-session.jsonl
@@ -1,0 +1,40 @@
+{"type":"user","uuid":"u-0001","message":{"content":"I want to add bazel-compatible caching as an experiment in the CI account."}}
+{"type":"assistant","uuid":"a-0001","message":{"content":[{"type":"thinking","thinking":"Look at the existing services first."},{"type":"tool_use","id":"toolu_01","name":"Glob","input":{"pattern":"**/*.yaml"}}]}}
+{"type":"user","uuid":"u-0002","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"catalog-info.yaml\npipeline.yaml"}]}}
+{"type":"last-prompt","lastPrompt":"I want to add bazel-compatible caching as an experiment in the CI account.","leafUuid":"u-0001","sessionId":"fixture-midturn"}
+{"type":"custom-title","customTitle":"Bazel-compatible caching options","sessionId":"fixture-midturn"}
+{"type":"ai-title","aiTitle":"Bazel remote cache onboarding","sessionId":"fixture-midturn"}
+{"type":"mode","mode":"normal","sessionId":"fixture-midturn"}
+{"type":"assistant","uuid":"a-0002","message":{"content":[{"type":"tool_use","id":"toolu_02","name":"Read","input":{"file_path":"catalog-info.yaml"}}]}}
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-07-29T06:11:00.000Z","sessionId":"fixture-midturn","content":"You can check ../base-infrastructure-for-services for any permission changes needed."}
+{"type":"user","uuid":"u-0003","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_02","content":"apiVersion: backstage.io/v1alpha1"}]}}
+{"type":"queue-operation","operation":"remove","timestamp":"2026-07-29T06:11:04.000Z","sessionId":"fixture-midturn","content":"You can check ../base-infrastructure-for-services for any permission changes needed."}
+{"parentUuid":"u-0003","isSidechain":false,"attachment":{"type":"queued_command","prompt":"You can check ../base-infrastructure-for-services for any permission changes needed.","source_uuid":"q-0001","commandMode":"prompt","origin":{"kind":"human"},"timestamp":"2026-07-29T06:11:00.000Z"},"type":"attachment","uuid":"at-0001","timestamp":"2026-07-29T06:11:00.000Z","userType":"external","cwd":"/repo","sessionId":"fixture-midturn","version":"2.1.219","gitBranch":"feat/remote-cache"}
+{"parentUuid":"at-0001","isSidechain":false,"attachment":{"type":"task_reminder","content":[],"itemCount":0},"type":"attachment","uuid":"at-0002","timestamp":"2026-07-29T06:11:05.000Z","sessionId":"fixture-midturn"}
+{"type":"assistant","uuid":"a-0003","message":{"content":[{"type":"tool_use","id":"toolu_03","name":"Grep","input":{"pattern":"iam","path":"../base-infrastructure-for-services"}}]}}
+{"type":"user","uuid":"u-0004","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_03","content":"iam.tf:12: resource \"aws_iam_role\""}]}}
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-07-29T07:02:00.000Z","sessionId":"fixture-midturn","content":"Also - please base the changes on _recent_ additions, it looks like the GHA stuff is circa 2022."}
+{"type":"queue-operation","operation":"remove","timestamp":"2026-07-29T07:02:03.000Z","sessionId":"fixture-midturn","content":"Also - please base the changes on _recent_ additions, it looks like the GHA stuff is circa 2022."}
+{"parentUuid":"u-0004","isSidechain":false,"attachment":{"type":"queued_command","prompt":"Also - please base the changes on _recent_ additions, it looks like the GHA stuff is circa 2022.","source_uuid":"q-0002","commandMode":"prompt","origin":{"kind":"human"},"timestamp":"2026-07-29T07:02:00.000Z"},"type":"attachment","uuid":"at-0003","timestamp":"2026-07-29T07:02:00.000Z","sessionId":"fixture-midturn"}
+{"type":"pr-link","sessionId":"fixture-midturn","prNumber":877,"prUrl":"https://example.invalid/org/repo/pull/877","prRepository":"org/repo","timestamp":"2026-07-29T07:34:29.380Z"}
+{"type":"assistant","uuid":"a-0004","message":{"content":[{"type":"text","text":"Renamed the stack components."},{"type":"tool_use","id":"toolu_04","name":"Edit","input":{"file_path":"stack.yaml"}}]}}
+{"type":"user","uuid":"u-0005","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_04","content":"edit failed: file not found","is_error":true}]}}
+{"parentUuid":"u-0005","isSidechain":false,"attachment":{"type":"queued_command","prompt":"Can you please rename stack components to the more generic `bre-remote-cache`? Or whatever acronym bazel remote execution prefers to use.","source_uuid":"q-0003","commandMode":"prompt","origin":{"kind":"human"},"timestamp":"2026-07-29T09:33:22.089Z"},"type":"attachment","uuid":"at-0004","timestamp":"2026-07-29T09:33:22.089Z","sessionId":"fixture-midturn"}
+{"type":"queue-operation","operation":"remove","timestamp":"2026-07-29T09:41:00.000Z","sessionId":"fixture-midturn","content":"Also - please compare to other BIFS services within the same repo, so continuous-integration related, not base-infrastructure-for-services."}
+{"type":"assistant","uuid":"a-0005","message":{"content":[{"type":"tool_use","id":"toolu_05","name":"Bash","input":{"command":"git status"}}]}}
+{"type":"user","uuid":"u-0006","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_05","content":"On branch feat/remote-cache"},{"type":"text","text":"Hold on - use the leaner shape, not the ci-athens one."}]}}
+{"type":"assistant","uuid":"a-0006","message":{"content":[{"type":"tool_use","id":"toolu_06","name":"Read","input":{"file_path":"pipeline.yaml"}}]}}
+{"type":"user","uuid":"u-0007","message":{"content":"The user sent a new message while you were working: Skip the GHA workflow entirely."}}
+{"parentUuid":"u-0007","isSidechain":false,"attachment":{"type":"edited_text_file","filename":"/repo/MAINTENANCE.md","snippet":"1\t# Maintenance\n2\t\n3\tThis file contains specific maintenance steps."},"type":"attachment","uuid":"at-0005","timestamp":"2026-07-29T09:50:00.000Z","sessionId":"fixture-midturn"}
+{"parentUuid":"at-0005","isSidechain":false,"attachment":{"type":"queued_command","prompt":"Scheduled follow-up: re-run the deploy check.","source_uuid":"q-0004","commandMode":"prompt","origin":{"kind":"cron"},"timestamp":"2026-07-29T09:55:00.000Z"},"type":"attachment","uuid":"at-0006","timestamp":"2026-07-29T09:55:00.000Z","sessionId":"fixture-midturn"}
+{"parentUuid":"at-0006","isSidechain":false,"attachment":{"type":"hook_blocking_error","hookName":"Stop","hookEvent":"Stop","blockingError":{"blockingError":"Please spawn a session-analyzer agent to critically analyze this session."}},"type":"attachment","uuid":"at-0007","timestamp":"2026-07-29T09:56:00.000Z","sessionId":"fixture-midturn"}
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-07-29T10:00:00.000Z","sessionId":"fixture-midturn","content":"Merged 6272. Can you inspect the comments on 877?"}
+{"type":"queue-operation","operation":"dequeue","timestamp":"2026-07-29T10:00:01.000Z","sessionId":"fixture-midturn","content":"Merged 6272. Can you inspect the comments on 877?"}
+{"type":"user","uuid":"u-0008","message":{"content":"Merged 6272. Can you inspect the comments on 877?"}}
+{"type":"assistant","uuid":"a-0007","message":{"content":[{"type":"tool_use","id":"toolu_07","name":"Bash","input":{"command":"gh pr view 877"}}]}}
+{"type":"user","uuid":"u-0009","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_07","content":"877 open"}]}}
+{"type":"assistant","uuid":"a-0008","message":{"content":[{"type":"tool_use","id":"toolu_08","name":"Bash","input":{"command":"gh pr diff 877"}}]}}
+{"type":"user","uuid":"u-0010","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_08","content":"diff --git a/stack.yaml b/stack.yaml"}]}}
+{"type":"assistant","uuid":"a-0009","message":{"content":[{"type":"text","text":"Done - the PR now uses the leaner shape."}]}}
+this line is not JSON and must be skipped
+{"type":"totally-unknown-future-type","uuid":"x-0001","payload":"kept as SYSTEM so a new user-bearing type is never invisible"}


### PR DESCRIPTION
TL;DR: messages you type while Claude is still working never reached the analyzer, so it judged explicitly-requested work as self-directed. Mid-turn input isn't a `user` entry at all - it arrives as a `queued_command` attachment, and the condenser had no case for it.

The concrete misfire that started this: the analyzer flagged a batch of work as "unilateral scope expansion ... unclear whether the user approved" when every piece of it was an explicit mid-turn request.

## Details

Claude Code queues a mid-turn message, then records the delivery as:

```jsonc
{"type":"queue-operation","operation":"remove","content":"Can you please rename stack components to..."}
{"type":"attachment","attachment":{"type":"queued_command",
  "prompt":"Can you please rename stack components to...","origin":{"kind":"human"}}}
```

`extractTranscript` handled `user` and `assistant` only, so both entries fell through to the catch-all `SYSTEM[<type>]: JSON.stringify(obj).slice(0, 200)`. Three failures compounded:

1. **Wrong branch** - the text became a JSON dump, cut mid-prompt (`parentUuid`, `isSidechain`, and `attachment.type` ate ~120 of the 200 chars).
2. **Lost the budget contest** - not being a `USER:` line, the fragment sat in the "other" bucket alongside 265 `TOOL_USE` and 264 `TOOL_RESULT` lines, of which only the last 4/5 of the 50 KB budget survived. It vanished entirely.
3. **Head-only user slice** - `userBuf.slice(0, USER_BUDGET)` kept the *earliest* user messages, so even a correctly labelled late ask was first to go.

On the session that prompted this, 4 of 10 real user messages were lost, and 311 of 1139 output lines were pure bookkeeping JSON crowding the budget.

## Changes

- Extract `queued_command` attachments as `USER (mid-turn):`, with `origin=<kind>` appended when the prompt came from automation rather than a person. The `queue-operation` `remove` record is a fallback used only when the attachment is absent, so the two encodings can't double up.
- Also treat text sharing a user entry with `tool_result` blocks, and text carrying "The user sent a new message while you were working" framing, as mid-turn. Neither occurs in the version I reproduced against, but both are plausible encodings of the same event.
- Surface `edited_text_file` attachments as `USER (edited file): <path>` - a file the user edited by hand is user action.
- Drop bookkeeping entries (`last-prompt`, titles, `pr-link`, `mode`, queue enqueue/dequeue, plumbing attachments) that duplicated real entries. Unknown types still fall through to `SYSTEM[...]`, so a future user-bearing type degrades to noisy rather than invisible.
- Protect every `USER` variant in the truncation path, and keep both ends of the user thread instead of only the head.
- Cut on line boundaries rather than `Buffer.slice`, which split mid-line and mid-UTF-8-char.
- Emit the `[TRUNCATED]` notice unconditionally. It was verbose-only, i.e. off by default, so a truncated transcript reached the analyzer with nothing marking it as truncated.
- Anchor project-local storage to the project root (nearest `.git`, else nearest `.claude`) rather than the shell's cwd at stop time, which had been scattering transcripts and cursors into `<repo>/<subdir>/.claude/tmp`. `.git` deliberately wins over `.claude`, because the old bug leaves a stray `.claude` in exactly the subdirectory that must not re-anchor.
- Tell the `session-analyzer` agent that mid-turn lines are authoritative user input, and that absence of an instruction in a truncated transcript is not evidence it was never given.

Condensation moves to `hooks/condense.mjs` so the tests can drive it directly, with an `extract`/`condense` CLI in the same shape as `cursor-slice.mjs`.

## Testing

`just check`: 53 pass, 0 fail. `just test-condense` adds 16 cases over `tests/fixtures/midturn-session.jsonl`, sanitised from the affected session, covering each encoding, the noise filtering, the byte budget under a realistic tool-traffic ratio, and the path anchoring.

The four lost messages are asserted verbatim. The test is non-vacuous: under the old logic the fixture yields one of them as a mangled `SYSTEM[...]` line and another **three** times, duplicated across `enqueue`/`remove`/`attachment`, so both the count and label assertions fail.

Re-ran the condenser on the original session (read-only) to confirm:

```
USER (mid-turn): You can check ../base-infrastructure-for-services for any permission changes needed.
USER (mid-turn): Also - please base the changes on _recent_ additions, it looks like the GHA stuff is circa 2022.
USER (mid-turn): Can you please rename stack components to the more generic `bre-remote-cache`? ...
USER (mid-turn): Also - please compare to other BIFS services within the same repo, ...

[DIAGNOSTICS] raw=258284B condensed=42975B user_messages=21 mid_turn_messages=4
```

## Notes for the reviewer

1. **Cursors reset once.** Sessions whose last cursor was written under a subdirectory won't find it at the new root, so the next run analyses from line 1. Self-healing, and `MIN_TOOL_USES`/cooldown still gate it, but the first post-upgrade analysis on such a session will be unusually broad.
2. **Version not bumped** - this repo does version bumps as their own `release:` commit.
3. **`design/condensed-transcript-cutoff.md` item 3 is now closed** by this PR (all three sub-points). Items 1 and 2 of that note - appending `event.last_assistant_message`, and giving each delta a goal anchor - are its highest-value fixes and remain open. Happy to do them as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
