### PR TITLE
Scope the analyzer to touched files, pass instruction files, tighten trigger gates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,8 +26,8 @@
     "min_tool_uses": {
       "type": "number",
       "title": "Minimum tool calls",
-      "description": "Skip analysis if the session delta has fewer tool calls than this. Default is 8",
-      "default": 8,
+      "description": "Skip analysis if the session delta has fewer tool calls than this. Default is 15",
+      "default": 15,
       "min": 0
     },
     "cooldown_seconds": {
@@ -67,6 +67,12 @@
       "type": "boolean",
       "title": "Skip while background tasks run",
       "description": "Skip analysis when background tasks (subagents, shell jobs, workflows) are still in flight, so the watchdog only reviews a session that's truly done, not one that's merely paused. Requires Claude Code >= 2.1.145; a no-op on older versions. Default is true",
+      "default": true
+    },
+    "include_rules": {
+      "type": "boolean",
+      "title": "Pass instruction files to the analyzer",
+      "description": "Point the analyzer at CLAUDE.md and .claude/rules/*.md (project, then ~/.claude) so it can check the session against your own instructions. Files over 8 KB are skipped; the list is capped at 16 KB total. Default is true",
       "default": true
     },
     "hold_input_during_analysis": {

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Only when **all** of these are true — otherwise it exits silently and Claude s
 - No background tasks are in flight (subagents, shell jobs, workflows) — a paused session isn't a finished one, so analysis waits for the next clean stop (unless disabled; requires Claude Code ≥ 2.1.145, no-op on older versions)
 - No session cron is already scheduled to run the analyzer (e.g. a `/loop /analyze-session`) — avoids doubling up. Gated by the **same** `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` flag as the background-task check, so disabling that flag re-enables this case too
 - Session has not already been analyzed (marker in the plugin's data directory, auto-expires after 2 hours)
-- Transcript exists and has ≥ configured minimum tool calls (default 8) in the unanalyzed delta
+- Transcript exists and has ≥ configured minimum tool calls (default 15) in the unanalyzed delta
+- The delta contains at least one file edit (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) or a non-read-only `Bash` command — read-only exploration turns are not reviewed
+- The delta contains at least one top-level user message
 - At least the configured cooldown (default 600s) has elapsed since the last analysis for this session
 - Condensed transcript is non-empty after filtering
 
@@ -97,12 +99,13 @@ with `/plugin configure claude-watchdog`:
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | Disable watchdog | `false` | Set to `true` to disable automatic session analysis |
-| Minimum tool calls | `8` | Skip analysis if the session delta has fewer tool calls than this |
+| Minimum tool calls | `15` | Skip analysis if the session delta has fewer tool calls than this |
 | Cooldown (seconds) | `600` | Minimum seconds between analyses for the same session. Set to `0` to disable |
 | Enable verbose mode | `false` | Prepend a diagnostics header to every condensed transcript and add truncation notices |
 | Store transcripts in project directory | `true` | Store session files under `.claude/tmp/claude-watchdog/` in the project directory instead of the global plugin data path. Eliminates Read permission prompts in `auto` mode. Requires `.claude/` in `.gitignore` |
 | Max transcript size (bytes) | `51200` | Maximum size of the condensed transcript sent to the analyzer (4 KB – 500 KB) |
 | Skip while background tasks run | `true` | Skip analysis when background tasks (subagents, shell jobs, workflows) are still in flight, so the watchdog only reviews a finished session, not a paused one. Requires Claude Code ≥ 2.1.145; a no-op on older versions |
+| Pass instruction files to the analyzer | `true` | Point the analyzer at `CLAUDE.md` and `.claude/rules/*.md` (project first, then `~/.claude`) so it can check the session against your own instructions. Files over 8 KB are skipped; the list is capped at 16 KB total |
 | Hold input while analysis runs | `false` | Block newly submitted prompts while an analysis is still in flight so they don't interleave with it. A held prompt is recoverable with up-arrow; resubmitting overrides the hold, and it auto-expires after 240 s |
 
 ### Environment variable overrides
@@ -114,7 +117,8 @@ take priority over the plugin config. Set these in your shell profile or
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `CLAUDE_WATCHDOG_DISABLED` | `0` | Set to `1` to disable the hook globally |
-| `CLAUDE_WATCHDOG_MIN_TOOL_USES` | `8` | Override minimum tool calls threshold |
+| `CLAUDE_WATCHDOG_MIN_TOOL_USES` | `15` | Override minimum tool calls threshold |
+| `CLAUDE_WATCHDOG_INCLUDE_RULES` | `1` | Set to `0` to stop passing `CLAUDE.md` / `.claude/rules/*.md` paths to the analyzer |
 | `CLAUDE_WATCHDOG_COOLDOWN_SECONDS` | `600` | Override cooldown between analyses |
 | `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` | `1` | Set to `0` to analyze even while background tasks (subagents, shell jobs, workflows) are still in flight. **This flag also gates the session-cron dedup guard** (see below), so setting it to `0` re-enables analysis in both cases |
 | `CLAUDE_WATCHDOG_HOLD_INPUT` | `0` | Set to `1` to hold newly submitted prompts while an analysis is in flight (see below) |

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -3,7 +3,7 @@ import {
   readFileSync, writeFileSync, appendFileSync, mkdirSync, readdirSync,
   statSync, unlinkSync, rmdirSync, existsSync, chmodSync
 } from 'node:fs';
-import { dirname, join, parse as parsePath, resolve } from 'node:path';
+import { dirname, join, parse as parsePath, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { slice, lastUuid } from './cursor-slice.mjs';
 import { extractTranscript, condense, counts } from './condense.mjs';
@@ -14,7 +14,7 @@ function cfg(watchdogVar, pluginVar, defaultVal) {
 
 const LOG_FILE = process.env.CLAUDE_WATCHDOG_LOG ?? join(homedir(), '.claude/logs/claude-watchdog.log');
 const MAX_LINES = parseInt(process.env.CLAUDE_WATCHDOG_LOG_MAX_LINES ?? '1000', 10);
-const MIN_TOOL_USES = parseInt(cfg('CLAUDE_WATCHDOG_MIN_TOOL_USES', 'CLAUDE_PLUGIN_OPTION_MIN_TOOL_USES', '8'), 10);
+const MIN_TOOL_USES = parseInt(cfg('CLAUDE_WATCHDOG_MIN_TOOL_USES', 'CLAUDE_PLUGIN_OPTION_MIN_TOOL_USES', '15'), 10);
 const CONDENSED_MAX_BYTES = parseInt(cfg('CLAUDE_WATCHDOG_MAX_BYTES', 'CLAUDE_PLUGIN_OPTION_MAX_TRANSCRIPT_BYTES', '51200'), 10);
 const WATCHDOG_TMP = process.env.CLAUDE_WATCHDOG_TMP ?? process.env.CLAUDE_PLUGIN_DATA ?? join(homedir(), '.claude/tmp/claude-watchdog');
 const GLOBAL_SESSIONS_DIR = join(WATCHDOG_TMP, 'sessions');
@@ -25,6 +25,7 @@ const LOCAL_STORAGE = cfg('CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE', 'CLAUDE_PLUGI
 const INTERACTIVE_RECS = cfg('CLAUDE_WATCHDOG_INTERACTIVE_RECOMMENDATIONS', 'CLAUDE_PLUGIN_OPTION_INTERACTIVE_RECOMMENDATIONS', '0');
 const SKIP_WITH_BG = cfg('CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS', 'CLAUDE_PLUGIN_OPTION_SKIP_WITH_BACKGROUND_TASKS', '1');
 const HOLD_INPUT = cfg('CLAUDE_WATCHDOG_HOLD_INPUT', 'CLAUDE_PLUGIN_OPTION_HOLD_INPUT_DURING_ANALYSIS', '0');
+const INCLUDE_RULES = cfg('CLAUDE_WATCHDOG_INCLUDE_RULES', 'CLAUDE_PLUGIN_OPTION_INCLUDE_RULES', '1');
 
 function log(msg) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -117,20 +118,87 @@ function projectRoot(startDir) {
   return claudeDir ?? start;
 }
 
-function countToolUses(lines) {
-  let count = 0;
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+const READ_ONLY_BASH = /^\s*(git diff|git log|git status|git show|ls|cat|grep|rg|find|head|tail|wc|sed -n)\b/;
+
+function parseLines(lines) {
+  const out = [];
   for (const line of lines) {
     if (!line || line[0] !== '{') continue;
-    try {
-      const obj = JSON.parse(line);
-      if (obj.type === 'assistant' && Array.isArray(obj.message?.content)) {
-        for (const block of obj.message.content) {
-          if (block.type === 'tool_use') count++;
-        }
-      }
-    } catch { /* skip malformed lines */ }
+    try { out.push(JSON.parse(line)); } catch { /* skip malformed lines */ }
   }
-  return count;
+  return out;
+}
+
+// Top-level user message: string content, or a text block with no tool_result.
+function isUserMessage(obj) {
+  if (obj.type !== 'user') return false;
+  const c = obj.message?.content;
+  if (typeof c === 'string') return c.trim().length > 0;
+  if (!Array.isArray(c)) return false;
+  return c.some(b => b.type === 'text') && !c.some(b => b.type === 'tool_result');
+}
+
+function deltaStats(entries, baseDir) {
+  let toolUses = 0, userMessages = 0, edits = 0, mutatingBash = 0;
+  const files = new Set();
+  const addFile = (f) => {
+    if (typeof f !== 'string' || !f) return;
+    let p = f;
+    if (baseDir && f.startsWith('/')) {
+      const rel = relative(baseDir, f);
+      if (rel && !rel.startsWith('..')) p = rel;
+    }
+    files.add(p.replace(/\n/g, ''));
+  };
+  for (const obj of entries) {
+    if (isUserMessage(obj)) userMessages++;
+    if (obj.type === 'attachment' && obj.attachment?.type === 'edited_text_file') addFile(obj.attachment.filename);
+    if (obj.type !== 'assistant' || !Array.isArray(obj.message?.content)) continue;
+    for (const block of obj.message.content) {
+      if (block.type !== 'tool_use') continue;
+      toolUses++;
+      if (EDIT_TOOLS.has(block.name)) {
+        edits++;
+        addFile(block.input?.file_path ?? block.input?.notebook_path);
+      } else if (block.name === 'Bash' && !READ_ONLY_BASH.test(String(block.input?.command ?? ''))) {
+        mutatingBash++;
+      }
+    }
+  }
+  return { toolUses, userMessages, edits, mutatingBash, files: [...files] };
+}
+
+function latestAnalysis(sessionId) {
+  try {
+    const names = readdirSync(ANALYSES_DIR).filter(f => f.startsWith(`${sessionId}-`) && f.endsWith('.md')).sort();
+    return names.length ? join(ANALYSES_DIR, names[names.length - 1]) : null;
+  } catch { return null; }
+}
+
+// Project-first, then global. Skips files >8KB, caps the total at 16KB.
+function instructionFiles(rootDir) {
+  const candidates = [];
+  const rulesIn = (dir) => {
+    try {
+      return readdirSync(dir).filter(f => f.endsWith('.md')).sort().map(f => join(dir, f));
+    } catch { return []; }
+  };
+  if (rootDir) {
+    candidates.push(join(rootDir, 'CLAUDE.md'), ...rulesIn(join(rootDir, '.claude/rules')));
+  }
+  const home = homedir();
+  candidates.push(join(home, '.claude/CLAUDE.md'), ...rulesIn(join(home, '.claude/rules')));
+  const out = [];
+  let total = 0;
+  for (const f of candidates) {
+    let size;
+    try { size = statSync(f).size; } catch { continue; }
+    if (size > 8192 || total + size > 16384) { log(`RULES: skipped ${f} (${size}B, ${size > 8192 ? 'over 8KB' : 'total cap'})`); continue; }
+    total += size;
+    out.push(f);
+  }
+  return out;
 }
 
 let markerDir = null;
@@ -345,10 +413,19 @@ try {
   const deltaLines = allLines.slice(deltaStart - 1);
   writeFileSync(DELTA_FILE, deltaLines.join('\n'));
 
-  const toolUseCount = countToolUses(deltaLines);
-  log(`tool_use count (delta): ${toolUseCount}`);
+  const stats = deltaStats(parseLines(deltaLines), hookCwd);
+  const toolUseCount = stats.toolUses;
+  log(`tool_use count (delta): ${toolUseCount} (edits=${stats.edits} mutating_bash=${stats.mutatingBash} user_messages=${stats.userMessages})`);
   if (toolUseCount < MIN_TOOL_USES) {
     log(`SKIP: delta too small (${toolUseCount} < ${MIN_TOOL_USES}), cursor unchanged`);
+    process.exit(0);
+  }
+  if (stats.edits === 0 && stats.mutatingBash === 0) {
+    log('SKIP: delta has no file edits or mutating shell commands (read-only turn), cursor unchanged');
+    process.exit(0);
+  }
+  if (stats.userMessages === 0) {
+    log('SKIP: delta has no top-level user messages, cursor unchanged');
     process.exit(0);
   }
 
@@ -394,25 +471,41 @@ try {
   if (isInteractive) {
     postAnalysis = `Present the full analysis to the user.
 
-Then, extract the recommendations from the Recommendations section. Use the AskUserQuestion tool to present them as actionable options:
+Then, extract the recommendations from the Recommendations section. Each is tagged [code], [instruction], or [process]. Use the AskUserQuestion tool to present them as actionable options:
 - question: "Which recommendations would you like to address?"
 - header: "Actions"
 - multiSelect: true
-- For each recommendation, create an option with the bold title as the label and the description as the description
+- For each recommendation, create an option with the bold title as the label and a description that starts with its tag (e.g. "[code] ...")
 
-If the user selects any recommendations, save them as a markdown checklist to '${safeTodoPath}' (create the directory if needed). Format each selected item as an unchecked task: "- [ ] recommendation text". If the file already exists, overwrite it.
+If the user selects any recommendations, save them as a markdown checklist to '${safeTodoPath}' (create the directory if needed). Put selected [instruction] items under a "## Rules to add" heading and all other selected items under a "## Tasks" heading; omit an empty heading. Format each item as an unchecked task: "- [ ] recommendation text". If the file already exists, overwrite it.
 
 Then stop.`;
   } else {
     postAnalysis = 'Present the analysis to the user, then stop.';
   }
 
+  const hadCursor = Boolean(cursorUuid);
+  const prevAnalysis = latestAnalysis(sessionId);
+  const rulesOn = INCLUDE_RULES === '1' || INCLUDE_RULES === 'true';
+  const rules = rulesOn ? instructionFiles(hookCwd && existsSync(hookCwd) ? projectRoot(hookCwd) : null) : [];
+  const promptLines = [
+    `Read and analyze the condensed session transcript at '${safeCondensed}'. The working directory is '${safeCwd}'.`,
+    hadCursor
+      ? 'This is a continuation: the transcript covers only work since the previous analysis.'
+      : 'This is the first analysis for this session.',
+    `Files touched this slice: ${stats.files.length ? stats.files.join(', ') : 'none'}`,
+  ];
+  if (prevAnalysis) promptLines.push(`Previous analysis (optional context, read only if useful): ${prevAnalysis.replace(/\n/g, '')}`);
+  if (rules.length) promptLines.push(`User instruction files: ${rules.join(', ')}`);
+  promptLines.push('Provide your critical analysis.');
+  const safePrompt = promptLines.join('\n').replace(/"/g, "'");
+
   const instruction = `Please spawn a session-analyzer agent to critically analyze this session.
 
 Use the Agent tool with:
 - subagent_type: "claude-watchdog:session-analyzer"
 - model: "sonnet"
-- prompt: "Read and analyze the condensed session transcript at '${safeCondensed}'. The working directory is '${safeCwd}'. Provide your critical analysis."
+- prompt: "${safePrompt}"
 
 ${postAnalysis}`;
 

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ smoke:
     transcript="$tmpdir/transcript.jsonl"
     for i in $(seq 1 5); do
       printf '{"type":"user","message":{"content":"do task %s"}}\n' "$i" >> "$transcript"
-      printf '{"type":"assistant","message":{"content":[{"type":"text","text":"Working on task %s"},{"type":"tool_use","id":"toolu_%s","name":"Read","input":{"file_path":"/tmp/test"}}]}}\n' "$i" "$i" >> "$transcript"
+      printf '{"type":"assistant","message":{"content":[{"type":"text","text":"Working on task %s"},{"type":"tool_use","id":"toolu_%s","name":"Edit","input":{"file_path":"/tmp/test","old_string":"a","new_string":"b"}}]}}\n' "$i" "$i" >> "$transcript"
       printf '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_%s","content":"file contents here"}]}}\n' "$i" >> "$transcript"
     done
     payload=$(jq -n --arg sid "$session_id" --arg tp "$transcript" --arg cwd "$PWD" \
@@ -45,6 +45,8 @@ smoke:
     # Default protocol: analysis is signalled via a JSON `decision:block` on stdout with exit 0.
     [ "$rc" -eq 0 ] || { echo "FAIL: expected exit 0, got $rc"; exit 1; }
     echo "$out" | grep -q '"decision":"block"' || { echo "FAIL: expected decision:block on stdout"; exit 1; }
+    echo "$out" | grep -q 'This is the first analysis for this session.' || { echo "FAIL: expected first-analysis marker in prompt"; exit 1; }
+    echo "$out" | grep -q 'Files touched this slice: /tmp/test' || { echo "FAIL: expected touched files in prompt"; exit 1; }
     # Input-hold is opt-in: the default run above must not write a pending sentinel.
     [ ! -f "$HOME/.claude/tmp/claude-watchdog/sessions/pending-${session_id}" ] || { echo "FAIL: pending sentinel written without opt-in"; exit 1; }
     # With the option on, a trigger writes a timestamped pending sentinel. Use a
@@ -76,7 +78,7 @@ test-cursor:
       if [ "$kind" = "user" ]; then
         jq -nc --arg u "$uuid" --arg t "$text" '{type:"user",uuid:$u,message:{content:$t}}'
       else
-        jq -nc --arg u "$uuid" --arg t "$text" '{type:"assistant",uuid:$u,message:{content:[{type:"text",text:$t},{type:"tool_use",id:("t_"+$u),name:"Read",input:{file_path:"/tmp/x"}}]}}'
+        jq -nc --arg u "$uuid" --arg t "$text" '{type:"assistant",uuid:$u,message:{content:[{type:"text",text:$t},{type:"tool_use",id:("t_"+$u),name:"Edit",input:{file_path:"/tmp/x",old_string:"a",new_string:"b"}}]}}'
       fi
     }
 


### PR DESCRIPTION
Spawn prompt now tells the analyzer what it is looking at:

- `Files touched this slice:` from Edit/Write/MultiEdit/NotebookEdit inputs and hand-edited attachments, so pre-existing working-tree changes are not attributed to the session.
- First analysis vs continuation, plus the path of the previous analysis for the session if one exists.
- `User instruction files:` project CLAUDE.md and rules, then global (8KB per file, 16KB total, skips logged). New `include_rules` option, default on.

Trigger gates, each with its own log reason:
- `min_tool_uses` default 8 -> 15.
- Skip read-only turns (no file edits and no mutating Bash).
- Skip deltas with no top-level user message.

Interactive recommendations expect `[code|instruction|process]` tags (prompt change lands in a separate PR) and write `[instruction]` items under a `## Rules to add` heading.

Behaviour change: fewer analyses fire by default. Suggest a minor version bump on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbRKxXEXNBYTqCs3hsMVMG