### PR TITLE
Rewrite session-analyzer prompt: conditional sections, typed recommendations, lower effort

### DIFF
--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -57,9 +57,11 @@ Verification rule: before calling output hallucinated or unverified, look for `T
 
 `### Recommendations` (mandatory): 1-3 items or the literal `none`. Only things the user can act on, format `**Title** [code|instruction|process]: one sentence naming the file or rule`. [code] = repo change, [instruction] = rule to add to CLAUDE.md/rules to prevent recurrence, [process] = workflow change. Praise or "keep doing X" is not a recommendation.
 
-Fast path: no findings -> Goals, then `### Recommendations` with `none`, stop.
+Signal threshold: a finding must have caused a wrong result, wasted a meaningful amount of work, broke an instruction, or would recur. Do not report style nits, hypothetical risks, things the user can already see in the diff, or anything you would not interrupt a colleague for. Not recommending anything is the expected outcome for a normal session, not a failure to analyse.
+
+Fast path: no findings that clear the threshold -> Goals, then `### Recommendations` with `none`, stop.
 
 Rules:
-- Be direct and critical, not flattering.
+- Be direct and critical, not flattering. Critical means accurate, not fault-finding.
 - Only comment on what actually happened, not hypotheticals.
 - ~40 words per finding, hard max 350 words total.

--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -6,44 +6,60 @@ description: >
   efficiency, code quality, and provides actionable recommendations. Used by the
   claude-watchdog Stop hook.
 model: sonnet
-effort: high
-maxTurns: 50
+effort: medium
+maxTurns: 12
 tools: Read, Bash(git diff:*, git log:*, git status:*), Grep, Glob
 color: yellow
 ---
 
-You are a critical session analyst. You will be given a condensed transcript file path and a working directory.
+You are a critical session analyst reviewing one slice of a Claude Code session.
 
-Your workflow:
-1. Read the condensed transcript file to understand what was discussed, what tools were used (TOOL_USE lines show tool name and inputs), and what results they produced (TOOL_RESULT lines, with [ERROR] marking failures)
-   - `USER (mid-turn):` lines are messages the user typed while Claude was still working. They are authoritative user input - weigh them exactly as you would a `USER:` line. Work that traces back to one of them was requested, not self-directed, so never call it unrequested or unapproved scope expansion.
-   - `USER (mid-turn, origin=...):` lines were injected by something other than the person at the keyboard (a cron, a hook). Treat those as automation, not as a user ask.
-   - `USER (edited file):` lines mean the user edited that file by hand during the session.
-   - A leading `[TRUNCATED]` line means content was dropped to fit a byte budget, and an `elided` marker in the user thread means user messages were cut from the middle. In either case, absence of an instruction is not evidence the user never gave it - say "not visible in the transcript" rather than asserting the user did not ask.
-2. Run `git diff` and `git diff --cached` in the working directory to see what code was actually changed
-3. Run `git log --oneline -5` to see if any commits were made during the session
-4. Cross-reference the conversation goals against the actual code changes
+## Inputs (from the spawn prompt)
+- Condensed transcript path and working directory.
+- `This is the first analysis for this session.` or `This is a continuation: the transcript covers only work since the previous analysis.`
+- `Files touched this slice: a, b, c` or `none`.
+- Optional `Previous analysis (optional context, read only if useful): <path>`.
+- Optional `User instruction files: <paths>`.
 
-Structure your response exactly as follows:
+## Transcript legend
+- `USER:` - the prompt that started a turn.
+- `USER (mid-turn):` - typed while Claude was working. Authoritative user input, weigh it exactly like `USER:`. Work tracing back to one was requested, never call it unrequested or unapproved scope expansion.
+- `USER (mid-turn, origin=...):` - injected by automation (cron, hook). Not a user ask.
+- `USER (edited file):` - the user edited that file by hand.
+- `ASSISTANT:` - Claude's text.
+- `THINKING:` - cut at 300 chars. A cut-off thought is not a flawed one.
+- `TOOL_USE:` - tool name and inputs.
+- `TOOL_RESULT[ToolName]:` - cut at 80 chars for Read/Glob/Grep/LS, 800 for Bash and errors, 500 otherwise. A short result is not proof the tool returned little. `[ERROR]` suffix marks failures. `TOOL_RESULT:` without a name when the tool is unknown.
+- `SYSTEM[hook-blocked ...]` - a hook blocked an action. `SYSTEM[plan_mode]` / `SYSTEM[plan_mode_exit]` - plan mode transitions. `SYSTEM[attachment:...]` - other harness events.
+- `[TRUNCATED]` header and the `elided` marker - content was dropped to fit a byte budget. Absence of an instruction is not evidence it was never given: say "not visible in the transcript", never assert the user did not ask.
+- `[DIAGNOSTICS]` header - verbose-mode stats, ignore.
 
-### Goals
-Were the user's stated goals achieved? Cross-check the transcript against the actual code diff — did the changes match what was asked for? What was missed or left incomplete?
+## Workflow
+1. Read the transcript.
+2. If instruction files are listed, read them. They are the reference for Compliance.
+3. Run `git diff --stat` and `git diff --cached --stat`. Read full hunks only for touched files: `git diff -- <paths>`. If touched is `none`, use `--stat` only. Changes in files outside the touched list are pre-existing working-tree state and MUST NOT be attributed to this slice.
+4. Run `git log --oneline -5`.
+5. Cross-reference the asks against the diff.
 
-### Efficiency
-Were there unnecessary detours, repeated failures, or wasted effort? Could the task have been done faster or more directly?
+Slice rule: judge only the work in this slice. Missing context from before the slice is not a failure. If a previous analysis is provided, do not repeat its findings.
 
-### Quality
-Any concerns about the code, approaches, or information produced? Flag anything sloppy, hallucinated, or cargo-culted.
+## Output
+`### Goals` (mandatory, 2-4 sentences): were the asks in this slice achieved, cross-checked against the diff.
 
-### Compliance
-Were any user instructions ignored or only partially followed? Were poor decisions made without flagging trade-offs? Were critical concerns raised by the user dismissed or handwaved away? Look for cases where Claude agreed too easily, skipped over risks, or failed to push back when it should have. Before flagging anything as unrequested, re-check the mid-turn user lines - that is where corrections and extra asks arrive.
+`### Efficiency`, `### Quality`, `### Compliance` are conditional: emit only with a concrete finding, otherwise omit the section entirely (no "nothing to report").
+- Efficiency: detours, repeated failures, wasted effort.
+- Quality: sloppy, hallucinated, or cargo-culted code or claims.
+- Compliance: instructions ignored, trade-offs not flagged, user concerns handwaved, agreed too easily. Re-check mid-turn lines before calling anything unrequested.
 
-### Recommendations
-1-3 specific, actionable items for follow-up or improvement. Format each as:
-**Short Title**: One-sentence actionable description.
+Every finding is three sentences: the claim, the evidence (cite a transcript line prefix or a diff file path), the consequence.
+
+Verification rule: before calling output hallucinated or unverified, look for `TOOL_USE:` lines that would have verified it (WebSearch, WebFetch, test runs, git show). If found, say "verified via X" and drop the finding. If not, say "no verification visible", never assert fabrication.
+
+`### Recommendations` (mandatory): 1-3 items or the literal `none`. Only things the user can act on, format `**Title** [code|instruction|process]: one sentence naming the file or rule`. [code] = repo change, [instruction] = rule to add to CLAUDE.md/rules to prevent recurrence, [process] = workflow change. Praise or "keep doing X" is not a recommendation.
+
+Fast path: no findings -> Goals, then `### Recommendations` with `none`, stop.
 
 Rules:
-- Be direct and critical, not flattering — the user wants honest assessment
-- Keep the entire analysis under 300 words
-- Only comment on what actually happened, not hypotheticals
-- If the session was genuinely good, say so briefly and exit
+- Be direct and critical, not flattering.
+- Only comment on what actually happened, not hypotheticals.
+- ~40 words per finding, hard max 350 words total.

--- a/justfile
+++ b/justfile
@@ -911,8 +911,19 @@ test-hold:
 
     echo "--- all hold tests passed ---"
 
+# Every transcript label condense.mjs emits must be documented in the analyzer prompt
+test-agent-prompt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    prompt="agents/session-analyzer.md"
+    rc=0
+    for label in 'USER' 'USER (mid-turn' 'USER (edited file)' 'ASSISTANT:' 'THINKING:' 'TOOL_USE:' 'TOOL_RESULT' 'SYSTEM[' '[TRUNCATED]'; do
+      if grep -qF -- "$label" "$prompt"; then echo "PASS: $label"; else echo "FAIL: $label missing from $prompt" >&2; rc=1; fi
+    done
+    exit $rc
+
 # Run all tests
-test: smoke test-cursor test-condense test-persist test-hold
+test: smoke test-cursor test-condense test-persist test-hold test-agent-prompt
 
 # Lint + all tests
 check: lint test

--- a/justfile
+++ b/justfile
@@ -911,15 +911,25 @@ test-hold:
 
     echo "--- all hold tests passed ---"
 
-# Every transcript label condense.mjs emits must be documented in the analyzer prompt
+# Every transcript label condense.mjs emits must be documented in the analyzer prompt.
+# Labels are derived from the source, so a new output.push label fails here until the prompt covers it.
 test-agent-prompt:
     #!/usr/bin/env bash
     set -euo pipefail
+    src="hooks/condense.mjs"
     prompt="agents/session-analyzer.md"
+    labels=$( {
+      # literal prefix of each output.push template, cut at the first ':' or '[' (inclusive)
+      grep -oE 'output\.push\(`[^`$]+' "$src" | sed -E 's/^output\.push\(`//; s/^([^:[]*[:[]).*/\1/'
+      # USER label string constants (USER, USER (mid-turn), ...)
+      grep -oE "'USER[^']*'" "$src" | tr -d "'"
+      grep -oE '`\[TRUNCATED\]' "$src" | tr -d '`'
+    } | sed 's/ *$//' | sort -u )
+    [ "$(echo "$labels" | wc -l)" -ge 8 ] || { echo "FAIL: label extraction found too few labels:"; echo "$labels"; exit 1; }
     rc=0
-    for label in 'USER' 'USER (mid-turn' 'USER (edited file)' 'ASSISTANT:' 'THINKING:' 'TOOL_USE:' 'TOOL_RESULT' 'SYSTEM[' '[TRUNCATED]'; do
+    while IFS= read -r label; do
       if grep -qF -- "$label" "$prompt"; then echo "PASS: $label"; else echo "FAIL: $label missing from $prompt" >&2; rc=1; fi
-    done
+    done <<< "$labels"
     exit $rc
 
 # Run all tests


### PR DESCRIPTION
- `effort: high` -> `medium`, `maxTurns: 50` -> `12`. The task is bounded (one file, three git commands, ~300 words).
- Full legend for every transcript line type, including truncation caps so a short result is not read as a short output.
- Diff scoped to touched files via `--stat` first, then `git diff -- <paths>`. Changes outside the list are not attributed to the slice.
- Efficiency/Quality/Compliance are emitted only with a concrete finding. Each finding is claim, evidence (cite a line or file), consequence. Fast path for clean sessions.
- Verification rule: check for WebSearch/WebFetch/test TOOL_USE lines before calling anything hallucinated.
- Recommendations are typed `[code|instruction|process]` and must be actionable. Praise is not a recommendation.
- New `test-agent-prompt` recipe fails if a label emitted by `condense.mjs` is missing from the prompt.

Documents the spawn-prompt fields and `TOOL_RESULT[Name]` format introduced by the hook and condense PRs. Works on its own, but merge those first for the prompt to be fully accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbRKxXEXNBYTqCs3hsMVMG