### PR TITLE
Give the analyzer the final message and honest failure markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ One line per event, prefixed with its kind:
 | `USER (mid-turn, origin=…):` | A queued prompt injected by automation (a cron, a hook) rather than by a person |
 | `USER (edited file):` | A file the user edited by hand during the session |
 | `ASSISTANT:` / `THINKING:` | Claude's replies and reasoning |
-| `TOOL_USE:` / `TOOL_RESULT:` | Tool calls and their results, truncated to 500 chars; `[ERROR]` marks failures |
+| `TOOL_USE:` / `TOOL_RESULT:` | Tool calls and their results, truncated to 500 chars; a failed or refused call is labelled `TOOL_RESULT[Name][ERROR]:` so the failure is read before the body |
 | `SYSTEM[…]:` | Everything else, including hook blocks and entry types the condenser doesn't know about |
+| `=== FINAL ASSISTANT MESSAGE (session ended here) ===` | Claude's concluding turn, appended after condensation so it is never truncated away — without it the transcript ends on tool results and the deliverable is invisible to the analyzer |
 
 Pure session bookkeeping (window titles, PR links, mode pings, the last-prompt cache, queue enqueue/dequeue records) is dropped — it duplicates real message entries and otherwise crowds real content out of the byte budget. When the transcript busts the budget, user messages are kept ahead of tool traffic, and both ends of the user thread are kept (the opening goal and the most recent asks) rather than only the beginning.
 

--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -29,7 +29,9 @@ You are a critical session analyst reviewing one slice of a Claude Code session.
 - `ASSISTANT:` - Claude's text.
 - `THINKING:` - cut at 300 chars. A cut-off thought is not a flawed one.
 - `TOOL_USE:` - tool name and inputs.
-- `TOOL_RESULT[ToolName]:` - cut at 80 chars for Read/Glob/Grep/LS, 800 for Bash and errors, 500 otherwise. A short result is not proof the tool returned little. `[ERROR]` suffix marks failures. `TOOL_RESULT:` without a name when the tool is unknown.
+- `TOOL_RESULT[ToolName][ERROR]:` - cut at 80 chars for Read/Glob/Grep/LS, 800 for Bash and errors, 500 otherwise. A short result is not proof the tool returned little. `TOOL_RESULT:` without a name when the tool is unknown.
+- `[ERROR]` in the label means the call failed or was refused: it did not take effect. The matching `TOOL_USE:` inputs are intent only - never delivered content, never evidence that a file was written, a command ran, or a change was made. Do not quote them as shipped output.
+- `=== FINAL ASSISTANT MESSAGE (session ended here) ===` - Claude's concluding turn, appended after the delta. This is the session's final response to the user; treat it as the deliverable when judging Goals. Absent if the turn ended without one.
 - `SYSTEM[hook-blocked ...]` - a hook blocked an action. `SYSTEM[plan_mode]` / `SYSTEM[plan_mode_exit]` - plan mode transitions. `SYSTEM[attachment:...]` - other harness events.
 - `[TRUNCATED]` header and the `elided` marker - content was dropped to fit a byte budget. Absence of an instruction is not evidence it was never given: say "not visible in the transcript", never assert the user did not ask.
 - `[DIAGNOSTICS]` header - verbose-mode stats, ignore.
@@ -53,7 +55,7 @@ Slice rule: judge only the work in this slice. Missing context from before the s
 
 Every finding is three sentences: the claim, the evidence (cite a transcript line prefix or a diff file path), the consequence.
 
-Verification rule: before calling output hallucinated or unverified, look for `TOOL_USE:` lines that would have verified it (WebSearch, WebFetch, test runs, git show). If found, say "verified via X" and drop the finding. If not, say "no verification visible", never assert fabrication.
+Verification rule: before calling output hallucinated or unverified, look for `TOOL_USE:` lines that would have verified it (WebSearch, WebFetch, test runs, git show) **and** check that their `TOOL_RESULT` came back without `[ERROR]`. A call that failed or was refused verifies nothing. If a successful call is found, say "verified via X" and drop the finding. If not, say "no verification visible", never assert fabrication.
 
 `### Recommendations` (mandatory): 1-3 items or the literal `none`. Only things the user can act on, format `**Title** [code|instruction|process]: one sentence naming the file or rule`. [code] = repo change, [instruction] = rule to add to CLAUDE.md/rules to prevent recurrence, [process] = workflow change. Praise or "keep doing X" is not a recommendation.
 

--- a/design/condensed-transcript-cutoff.md
+++ b/design/condensed-transcript-cutoff.md
@@ -1,0 +1,70 @@
+# Design note: session-analyzer receives cut-off transcripts
+
+**Status:** Fix #1 implemented (final assistant message appended). #2–#5 outstanding.
+**Date:** 2026-07-07
+**Scope:** `hooks/session-analysis.mjs`, `hooks/cursor-slice.mjs`, `hooks/persist-analysis.mjs`, `agents/session-analyzer.md`
+**Relationship to other work:** Orthogonal to the trigger-timing hardening (PR #8 `stop_hook_active`, the `background_tasks` gap). Those govern *when* the Stop hook fires; this note is about *what content* the analyzer receives once it does.
+
+---
+
+## Symptom
+
+The `session-analyzer` agent repeatedly misreports that the session "ended mid-task" / "the transcript cuts off before the final output was produced," and guesses at or mislabels the session goal ("this appears to be a separate/unclear task"). This has been happening more frequently on longer, MCP-heavy sessions (Slack, Datadog, etc.).
+
+Across one multi-turn session that produced four complete deliverable drafts (v1–v4), *every* analyzer run claimed the final draft may not have been produced — even though each draft was, in fact, delivered.
+
+## Root cause
+
+Confirmed from the actual condensed file fed to the analyzer for this session. Its `[DIAGNOSTICS]` header read:
+
+```
+raw=39282B condensed=39282B ... delta_start=139
+```
+
+`raw == condensed`, so **the byte-size truncation (`CONDENSED_MAX_BYTES`, default 51200) never fired.** The size cap is not the cause. Two other mechanisms are:
+
+### 1. Incremental deltas start mid-session with no goal anchor
+`delta_start=139` means the condensed file begins at transcript line 139. The cursor/delta mechanism (`hooks/cursor-slice.mjs`) advances each run, so every analysis after the first **excludes the original objective and all earlier work**. The file opens on a bare `SYSTEM[last-prompt]` metadata line with zero framing — hence the analyzer repeatedly guessing at, or misidentifying, the task.
+
+### 2. The final assistant message is absent from the delta
+The last `ASSISTANT:` line captured in the delta is the model *announcing* an action (e.g. "Let me search the inverse…"), after which the file ends on tool-results plus the `SYSTEM[last-prompt]` line. The concluding assistant turn — the actual synthesized deliverable — **is not in the file at all.** So "the transcript cuts off before the final output was produced" was *literally true of the input handed to the analyzer*, every time, even though the session did produce that output.
+
+### Why "more and more lately"
+Longer, MCP-heavy sessions produce large deltas with lots of trailing tool-result noise. The tail the analyzer sees is increasingly tool-results rather than the concluding assistant turn, making the "cut off before the answer" artifact more likely.
+
+## Recommended fixes (ranked)
+
+### 1. Append the final assistant message, explicitly anchored — *highest value*
+`event.last_assistant_message` is already provided by Claude Code and is already consumed in `hooks/persist-analysis.mjs:26` (`event.last_assistant_message ?? ''`), but **not** in `session-analysis.mjs`. After building `condensedContent`, append it under a clear header, e.g.:
+
+```
+=== FINAL ASSISTANT MESSAGE (session ended here) ===
+```
+
+Feature-detect with `event.last_assistant_message ?? ''`. This single change removes the recurring "cuts off before final output" misdiagnosis.
+
+### 2. Give the delta a goal anchor
+Because analysis is incremental, prepend the session's **first user message** (or persist it alongside the cursor in `cursor-slice.mjs`) so post-first-run deltas still carry the original objective. Fixes the "unclear / separate task" misfires.
+
+### 3. Fix the truncation path for when it *does* fire (`session-analysis.mjs:378–392`)
+- `userBuf.slice(0, USER_BUDGET)` (line 392) keeps the **oldest** user turns and drops the most recent instruction. Invert to `.slice(-USER_BUDGET)`, or keep first + last.
+- Emit the `[TRUNCATED]` notice **unconditionally**, not only in verbose mode — otherwise a genuinely truncated file reads to the analyzer as a session that ended early.
+- Trim byte-slices to line boundaries. `.slice(0, N)` / `.slice(-N)` cut mid-line and mid-UTF-8-char, producing garbled partial lines that themselves read as "cut off."
+
+### 4. Stop assuming a code session (`agents/session-analyzer.md`)
+The agent hard-codes a `git diff` / `git log` workflow and a rubric that cross-checks findings against the code diff. For non-code sessions (e.g. a drafting task) — or a working dir that isn't a git repo — that workflow yields nothing and the goal-check misfires. Add a branch: if there's no git repo / no diff, evaluate the transcript on its own terms.
+
+### 5. Minor — raise/document the byte cap
+`CLAUDE_WATCHDOG_MAX_BYTES` default of 51200 (`session-analysis.mjs:17`) is low for MCP-heavy turns. Worth raising or documenting, though fixes #1 and #2 do the real work.
+
+## Suggested sequencing
+Fixes **#1 + #2** resolve the immediate, recurring pain and are low-risk. **#3 + #4** harden the edges. **#5** is cleanup.
+
+## Verification notes
+File paths and symbols referenced above were confirmed present on `main` at time of writing:
+- `session-analysis.mjs:17` — `CONDENSED_MAX_BYTES` default `51200`
+- `session-analysis.mjs:378–392` — truncation path; `USER_BUDGET` (385), `userBuf.slice(0, USER_BUDGET)` (392)
+- `session-analysis.mjs:411` — `[DIAGNOSTICS]` header emission
+- `persist-analysis.mjs:26` — existing `event.last_assistant_message ?? ''` usage (precedent for fix #1)
+- `hooks/cursor-slice.mjs` — delta/cursor mechanism (fix #2)
+- `agents/session-analyzer.md` — hard-coded git rubric (fix #4)

--- a/hooks/condense.mjs
+++ b/hooks/condense.mjs
@@ -126,8 +126,10 @@ export function extractTranscript(lines) {
             output.push(`${label}: ${text.replace(MIDTURN_FRAMING, '')}`);
           } else if (block.type === 'tool_result') {
             const name = toolNames.get(block.tool_use_id);
-            const label = name ? `TOOL_RESULT[${name}]` : 'TOOL_RESULT';
-            output.push(`${label}: ${toolResultText(block, name)}${block.is_error === true ? ' [ERROR]' : ''}`);
+            // [ERROR] goes in the label, not after a body that can run 800 chars:
+            // the reader must see the failure before the content it did not produce.
+            const label = `${name ? `TOOL_RESULT[${name}]` : 'TOOL_RESULT'}${block.is_error === true ? '[ERROR]' : ''}`;
+            output.push(`${label}: ${toolResultText(block, name)}`);
           }
         }
       }

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -442,6 +442,14 @@ try {
   const { content, rawSize } = condense(rawContent, CONDENSED_MAX_BYTES);
   let condensedContent = content;
 
+  // The delta ends on tool results, so the concluding turn - the deliverable the
+  // analyzer must judge - is absent. Appended after condense() so it is never
+  // truncated away.
+  const finalMsg = event.last_assistant_message ?? '';
+  if (finalMsg.trim()) {
+    condensedContent += `\n\n=== FINAL ASSISTANT MESSAGE (session ended here) ===\n${finalMsg}\n`;
+  }
+
   if (isVerbose) {
     const { user, midTurn } = counts(condensedContent);
     const condensedSize = Buffer.byteLength(condensedContent, 'utf8');

--- a/justfile
+++ b/justfile
@@ -720,19 +720,21 @@ test-condense:
 
     # --- Test 9: tool_result lines carry the tool name, errors still flagged ---
     grep -q '^TOOL_RESULT\[Bash\]: On branch feat/remote-cache$' "$out" || fail "tool-result-kept" "tool_result not condensed into a TOOL_RESULT[Bash] line"
-    grep -q '^TOOL_RESULT\[Edit\]: edit failed: file not found \[ERROR\]$' "$out" || fail "tool-result-error" "tool_result error flag lost"
+    # [ERROR] belongs in the label: a Bash/error body runs to 800 chars, so a suffix
+    # is read only after the content the call never actually produced.
+    grep -q '^TOOL_RESULT\[Edit\]\[ERROR\]: edit failed: file not found$' "$out" || fail "tool-result-error" "tool_result error flag lost or not in the label"
     grep -q '^TOOL_RESULT: orphan result$' "$out" || fail "tool-result-unknown" "result with unknown tool_use_id should be unlabelled"
     pass "tool-result-condensing-intact"
 
     # --- Test 9b: per-tool result caps (payload 1000 chars; cap + label + marker) ---
     # result_len <marker> -> length of the payload after the label
-    result_len() { grep -F "$1" "$out" | sed 's/^TOOL_RESULT[^:]*: //; s/ \[ERROR\]$//' | awk '{print length($0)}'; }
+    result_len() { grep -F "$1" "$out" | sed 's/^TOOL_RESULT[^:]*: //' | awk '{print length($0)}'; }
     [ "$(result_len 'READCAP')" = "80" ] || fail "cap-read" "Read result should be capped at 80, got $(result_len 'READCAP')"
     [ "$(result_len 'BASHCAP')" = "800" ] || fail "cap-bash" "Bash result should be capped at 800, got $(result_len 'BASHCAP')"
     [ "$(result_len 'WRITECAP')" = "500" ] || fail "cap-default" "Write result should be capped at 500, got $(result_len 'WRITECAP')"
     [ "$(result_len 'WRITEERR')" = "800" ] || fail "cap-error" "is_error result should be capped at 800, got $(result_len 'WRITEERR')"
     [ "$(result_len 'MCPCAP')" = "500" ] || fail "cap-mcp" "mcp__fs__Read must not get the Read cap, got $(result_len 'MCPCAP')"
-    grep -q '^TOOL_RESULT\[Write\]: WRITEERR .* \[ERROR\]$' "$out" || fail "cap-error-label" "error result lost its [Name] label or [ERROR] suffix"
+    grep -q '^TOOL_RESULT\[Write\]\[ERROR\]: WRITEERR ' "$out" || fail "cap-error-label" "error result lost its [Name] label or [ERROR] marker"
     pass "tool-result-per-tool-caps"
 
     # --- Test 10: under the byte budget, mid-turn lines survive tool-call flood ---
@@ -925,7 +927,8 @@ test-hold:
 
     echo "--- all hold tests passed ---"
 
-# Every transcript label condense.mjs emits must be documented in the analyzer prompt.
+# Every transcript label condense.mjs emits must be documented in the analyzer prompt,
+# and the prompt assembly must hand the analyzer the final assistant message.
 # Labels are derived from the source, so a new output.push label fails here until the prompt covers it.
 test-agent-prompt:
     #!/usr/bin/env bash
@@ -944,6 +947,50 @@ test-agent-prompt:
     while IFS= read -r label; do
       if grep -qF -- "$label" "$prompt"; then echo "PASS: $label"; else echo "FAIL: $label missing from $prompt" >&2; rc=1; fi
     done <<< "$labels"
+
+    # --- The condensed file the hook writes must end with the final assistant message ---
+    # The delta ends on tool results, so without this the analyzer is asked to judge
+    # whether the deliverable was produced while never being shown it.
+    TMPROOT=$(mktemp -d)
+    trap 'rm -rf "$TMPROOT"' EXIT
+    FIXTURE="tests/fixtures/midturn-session.jsonl"
+    HEADER='=== FINAL ASSISTANT MESSAGE (session ended here) ==='
+    FINAL_TEXT='Renamed the stack components to bre-remote-cache and pushed the branch.'
+
+    run_hook() { # run_hook <session-id> <payload-json> -> echoes condensed file path
+      local sid="$1" payload="$2" tmp="$TMPROOT/w-$1"
+      echo "$payload" | CLAUDE_WATCHDOG_LOG="$TMPROOT/hook-$sid.log" CLAUDE_WATCHDOG_TMP="$tmp" \
+        CLAUDE_WATCHDOG_ANALYSES_DIR="$TMPROOT/analyses" CLAUDE_WATCHDOG_LOCAL_SESSION_STORAGE=0 \
+        CLAUDE_WATCHDOG_MIN_TOOL_USES=3 CLAUDE_WATCHDOG_COOLDOWN_SECONDS=0 \
+        node hooks/session-analysis.mjs >/dev/null 2>&1
+      echo "$tmp/sessions/condensed-${sid}.txt"
+    }
+
+    sid="final-msg-$$"
+    cwd="$TMPROOT/project"; mkdir -p "$cwd"
+    payload=$(jq -n --arg sid "$sid" --arg tp "$FIXTURE" --arg cwd "$cwd" --arg msg "$FINAL_TEXT" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", last_assistant_message:$msg}')
+    f=$(run_hook "$sid" "$payload")
+    [ -f "$f" ] || { cat "$TMPROOT/hook-$sid.log"; echo "FAIL: hook wrote no condensed file" >&2; rc=1; }
+    if [ -f "$f" ]; then
+      grep -qF "$HEADER" "$f" || { echo "FAIL: condensed file missing the final-message header" >&2; rc=1; }
+      grep -qF "$FINAL_TEXT" "$f" || { echo "FAIL: final assistant message not in condensed file" >&2; rc=1; }
+      # must be the tail, after the tool traffic - not buried mid-transcript
+      tail -3 "$f" | grep -qF "$FINAL_TEXT" || { tail -5 "$f"; echo "FAIL: final message is not at the end of the file" >&2; rc=1; }
+      grep -qF "$HEADER" "$prompt" || { echo "FAIL: $HEADER undocumented in $prompt" >&2; rc=1; }
+      if [ "$rc" = "0" ]; then echo "PASS: $HEADER"; fi
+    fi
+
+    # Absent from the event -> no empty header stanza.
+    sid2="final-msg-none-$$"
+    payload2=$(jq -n --arg sid "$sid2" --arg tp "$FIXTURE" --arg cwd "$cwd" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn"}')
+    f2=$(run_hook "$sid2" "$payload2")
+    if [ -f "$f2" ] && grep -qF "$HEADER" "$f2"; then
+      echo "FAIL: header emitted with no last_assistant_message" >&2; rc=1
+    else
+      echo "PASS: no final-message header when the event carries none"
+    fi
     exit $rc
 
 # Run all tests


### PR DESCRIPTION
Two gaps that produced false session-analyzer findings, both confirmed against a real incident today.

**The analyzer was asked to judge deliverables it was never shown.** `event.last_assistant_message` is provided by Claude Code and already consumed in `persist-analysis.mjs`, but `session-analysis.mjs` never read it. The delta ends on tool results, so the concluding turn was absent from the condensed file while `### Goals` is mandatory in the prompt ("were the asks in this slice achieved"). It is now appended after `condense()`, under a `=== FINAL ASSISTANT MESSAGE (session ended here) ===` header, so truncation can never drop it.

**A refused command's input was quoted back as shipped content.** The data pipeline was already correct: the condensed file had the `TOOL_USE` heredoc and its refused `TOOL_RESULT` on adjacent lines. The gap was the prompt, which said only "`[ERROR]` suffix marks failures" - it documented that the marker exists and never said what it means. Three changes:

- The legend now states that a call carrying `[ERROR]` did not take effect, and that the matching `TOOL_USE` inputs are intent only, never delivered content and never evidence that a change was made.
- The verification rule asked for `TOOL_USE` lines that "would have verified" a claim, with no requirement that the call succeeded, so a failed test run counted as verification. It now requires the result came back without `[ERROR]`.
- `[ERROR]` moves from a suffix into the label (`TOOL_RESULT[Bash][ERROR]:`), so the failure is read before a body that runs to 800 chars for Bash and errors.

`design/condensed-transcript-cutoff.md` is now tracked. This implements its ranked fix #1. Fixes #2 (goal anchor) and #3 (truncation path) were not implicated in this incident and are untouched.

One side effect worth knowing: the verbose `[DIAGNOSTICS]` `condensed=` count now includes the appended final message, so `raw == condensed` is no longer the truncation signal. `condense()` already emits `[TRUNCATED]` unconditionally, which is the reliable one.

<details><summary><b>Verification</b></summary>

`just check` passes: lint clean, 64 test assertions across `smoke test-cursor test-condense test-persist test-hold test-agent-prompt`.

New assertions in `test-agent-prompt` run the real Stop hook twice against the `midturn-session.jsonl` fixture, once with `last_assistant_message` set and once without, and check the condensed file the hook actually wrote:

- the header and the message text are present,
- the message is in the last three lines, so it lands after the tool traffic rather than buried mid-transcript,
- the header is documented in `agents/session-analyzer.md`,
- no empty header stanza when the event carries no final message.

`test-condense` tests 9 and 9b are updated for the label form. Test 9b already covers the property that matters for the move: a 1000-char error payload capped at 800 still shows `[ERROR]` before the body. `result_len()` loses its now-redundant suffix strip.

No coverage tooling in this repo. The suite is bash assertions against real hook output, so there is nothing to instrument.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
