### PR TITLE
fix: don't duplicate the final assistant message when it is already on disk

### DIFF
--- a/design/condensed-transcript-cutoff.md
+++ b/design/condensed-transcript-cutoff.md
@@ -1,6 +1,6 @@
 # Design note: session-analyzer receives cut-off transcripts
 
-**Status:** Fix #1 implemented (final assistant message appended). #2–#5 outstanding.
+**Status:** Fix #1 implemented (final assistant message appended, deduped when the transcript flush beat the hook). #2–#5 outstanding.
 **Date:** 2026-07-07
 **Scope:** `hooks/session-analysis.mjs`, `hooks/cursor-slice.mjs`, `hooks/persist-analysis.mjs`, `agents/session-analyzer.md`
 **Relationship to other work:** Orthogonal to the trigger-timing hardening (PR #8 `stop_hook_active`, the `background_tasks` gap). Those govern *when* the Stop hook fires; this note is about *what content* the analyzer receives once it does.

--- a/hooks/session-analysis.mjs
+++ b/hooks/session-analysis.mjs
@@ -445,8 +445,13 @@ try {
   // The delta ends on tool results, so the concluding turn - the deliverable the
   // analyzer must judge - is absent. Appended after condense() so it is never
   // truncated away.
-  const finalMsg = event.last_assistant_message ?? '';
-  if (finalMsg.trim()) {
+  const finalMsg = (event.last_assistant_message ?? '').trim();
+  // The flush is a race, not a guarantee: on a slower turn the message is already
+  // on disk and in the delta, and appending unconditionally would duplicate it.
+  // Probe on the tail so a message split across several text blocks still matches
+  // its own last ASSISTANT line.
+  const alreadyPresent = finalMsg && condensedContent.includes(finalMsg.slice(-200));
+  if (finalMsg && !alreadyPresent) {
     condensedContent += `\n\n=== FINAL ASSISTANT MESSAGE (session ended here) ===\n${finalMsg}\n`;
   }
 

--- a/justfile
+++ b/justfile
@@ -991,6 +991,22 @@ test-agent-prompt:
     else
       echo "PASS: no final-message header when the event carries none"
     fi
+
+    # Already flushed to the transcript -> appended copy would be a duplicate.
+    sid3="final-msg-dupe-$$"
+    ON_DISK='Renamed the stack components.'
+    payload3=$(jq -n --arg sid "$sid3" --arg tp "$FIXTURE" --arg cwd "$cwd" --arg msg "$ON_DISK" \
+      '{session_id:$sid, transcript_path:$tp, cwd:$cwd, stop_reason:"end_turn", last_assistant_message:$msg}')
+    f3=$(run_hook "$sid3" "$payload3")
+    if [ ! -f "$f3" ]; then
+      echo "FAIL: hook wrote no condensed file for the dedupe case" >&2; rc=1
+    elif grep -qF "$HEADER" "$f3"; then
+      echo "FAIL: final message re-appended although it is already in the transcript" >&2; rc=1
+    elif [ "$(grep -cF "$ON_DISK" "$f3")" != "1" ]; then
+      echo "FAIL: final message appears $(grep -cF "$ON_DISK" "$f3") times, expected 1" >&2; rc=1
+    else
+      echo "PASS: no duplicate when the final message already reached the transcript"
+    fi
     exit $rc
 
 # Run all tests


### PR DESCRIPTION
Closes #15 - the last piece of it. #20 already appends `event.last_assistant_message` to the condensed transcript; what was missing is the dedupe guard the issue called for.

The flush is a race, not a guarantee. On a slower turn the final message is already in the delta on disk, so the unconditional append hands the analyzer the same conclusion twice.

- Skip the append when the condensed content already contains the message.
- Probe on the last 200 chars, so a message split across several text blocks still matches its own last `ASSISTANT` line.
- Check the condensed text rather than the raw one - a message dropped by truncation still gets appended.

Test: new case in `just test-agent-prompt` feeds a `last_assistant_message` that is already in the fixture and asserts the header is absent and the text appears exactly once. Verified it fails without the change.