### PR TITLE
feat: add opt-in PreToolUse hook enforcing pinned subagent models

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -80,6 +80,12 @@
       "title": "Hold input while analysis runs",
       "description": "Block newly submitted prompts while a session analysis is still in flight, so they don't interleave with the pending analysis. A held prompt is recoverable with up-arrow; resubmitting overrides the hold. The hold auto-expires after 240 seconds. Default is false",
       "default": false
+    },
+    "enforce_subagent_model": {
+      "type": "boolean",
+      "title": "Enforce pinned subagent models",
+      "description": "Block a Task/Agent dispatch that names an agent whose definition pins a 'model:' but does not pass an explicit 'model'. Re-dispatching with any explicit model passes. Default is false",
+      "default": false
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Run a short session and end Claude's turn. You should see output like:
 | Condenser | `hooks/condense.mjs` | Turns the raw JSONL into the condensed transcript, within a byte budget |
 | SubagentStop hook | `hooks/persist-analysis.mjs` | Persists the analyzer's output to disk (no UI noise) |
 | UserPromptSubmit hook | `hooks/hold-input.mjs` | Optionally holds new prompts while an analysis is in flight |
+| PreToolUse hook | `hooks/enforce-subagent-model.mjs` | Optionally blocks a `Task`/`Agent` dispatch that ignores an agent's pinned model |
 | Subagent | `agents/session-analyzer.md` | Reads the transcript + `git diff`, writes the review |
 | Slash command | `skills/analyze-session/SKILL.md` | `/analyze-session` for on-demand analysis mid-conversation |
 
@@ -110,6 +111,7 @@ with `/plugin configure claude-watchdog`:
 | Skip while background tasks run | `true` | Skip analysis when background tasks (subagents, shell jobs, workflows) are still in flight, so the watchdog only reviews a finished session, not a paused one. Requires Claude Code ≥ 2.1.145; a no-op on older versions |
 | Pass instruction files to the analyzer | `true` | Point the analyzer at `CLAUDE.md` and `.claude/rules/*.md` (project first, then `~/.claude`) so it can check the session against your own instructions. Files over 8 KB are skipped; the list is capped at 16 KB total |
 | Hold input while analysis runs | `false` | Block newly submitted prompts while an analysis is still in flight so they don't interleave with it. A held prompt is recoverable with up-arrow; resubmitting overrides the hold, and it auto-expires after 240 s |
+| Enforce pinned subagent models | `false` | Block a `Task`/`Agent` dispatch that names an agent whose definition pins a `model:` but passes no explicit `model` |
 
 ### Environment variable overrides
 
@@ -125,6 +127,7 @@ take priority over the plugin config. Set these in your shell profile or
 | `CLAUDE_WATCHDOG_COOLDOWN_SECONDS` | `600` | Override cooldown between analyses |
 | `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` | `1` | Set to `0` to analyze even while background tasks (subagents, shell jobs, workflows) are still in flight. **This flag also gates the session-cron dedup guard** (see below), so setting it to `0` re-enables analysis in both cases |
 | `CLAUDE_WATCHDOG_HOLD_INPUT` | `0` | Set to `1` to hold newly submitted prompts while an analysis is in flight (see below) |
+| `CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL` | `0` | Set to `1` to block a `Task`/`Agent` dispatch that ignores an agent's pinned model (see below) |
 
 ### Advanced overrides
 
@@ -162,6 +165,31 @@ Two caveats: a prompt that lands in the instant between the analyzer finishing a
 Claude presenting the analysis is not held (the analysis is already persisted to
 the analyses directory at that point), and the hook adds one Node cold-start
 (~30–80 ms) to every prompt submission while the plugin is installed.
+
+### Enforcing pinned subagent models
+
+An agent definition can pin a model in its frontmatter:
+
+```markdown
+---
+name: cheap-reviewer
+model: haiku
+---
+```
+
+Claude Code honours that pin only when the dispatch leaves `model` unset - passing
+`model` explicitly overrides it, which is easy to do by accident and silently moves
+the work onto a different (usually pricier) model.
+
+With **Enforce pinned subagent models** enabled, a `PreToolUse` hook blocks any
+`Task`/`Agent` dispatch that names a pinned agent without an explicit `model`, and
+tells Claude which model to re-dispatch with. A deliberate override still passes -
+the point is that it has to be deliberate, not implicit.
+
+The agent definition is looked up as `<agent>.md` or `<agent>/<agent>.md`, first
+under `$CLAUDE_PROJECT_DIR/.claude/agents`, then `~/.claude/agents`. An agent with
+no `model:` key, or `model: inherit`, is never enforced. Every other path allows the
+dispatch, so a malformed definition or an unreadable directory cannot wedge Claude.
 
 You can also create a `.claude-watchdog-skip` file to disable the hook for a project. The hook looks for it in the session's working directory, so put it at the directory you start Claude Code from:
 

--- a/design/contract.md
+++ b/design/contract.md
@@ -21,13 +21,14 @@ Conventions used below:
 
 ## 1. Entry points
 
-Three hooks, wired in `hooks/hooks.json`:
+Four hooks, wired in `hooks/hooks.json`:
 
 | Event | Matcher | Command | Timeout |
 | --- | --- | --- | --- |
 | `Stop` | `""` (all) | `node ${CLAUDE_PLUGIN_ROOT}/hooks/session-analysis.mjs` | 120 s |
 | `UserPromptSubmit` | `""` (all) | `node ${CLAUDE_PLUGIN_ROOT}/hooks/hold-input.mjs` | 10 s |
 | `SubagentStop` | `session-analyzer` | `node ${CLAUDE_PLUGIN_ROOT}/hooks/persist-analysis.mjs` | 10 s |
+| `PreToolUse` | `Task\|Agent` | `node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-subagent-model.mjs` | 10 s |
 
 Two further files are libraries with a debug CLI attached, not hooks:
 `hooks/condense.mjs` and `hooks/cursor-slice.mjs` (section 9).
@@ -42,6 +43,7 @@ as UTF-8 and `JSON.parse`s it.
 | Stop | 65536 bytes | Truncated buffer almost certainly fails `JSON.parse`, which is caught, logged as `ERROR:`, and exits 0. **[UNTESTED]** |
 | UserPromptSubmit | 65536 bytes | Same, logged with the `[hold]` prefix. Garbage stdin is tested; the cap itself is not. |
 | SubagentStop | 131072 bytes | Same, logged with the `[persist]` prefix. **[UNTESTED]** |
+| PreToolUse | 65536 bytes | Same, logged with the `[model]` prefix. Garbage stdin is tested; the cap itself is not. |
 
 The cap slices *bytes* before decoding, so a multi-byte character straddling the
 cap decodes to U+FFFD. This only ever makes the parse fail sooner, and the parse
@@ -79,6 +81,11 @@ never read and never logged, by design.
 SubagentStop event (`persist-analysis.mjs`): `agent_type` (gate, must equal
 `session-analyzer`), `session_id` (gate, same regex), and
 `last_assistant_message` (the content written to disk).
+
+PreToolUse event (`enforce-subagent-model.mjs`): `tool_name` (gate, must be
+`Task` or `Agent`), `tool_input.subagent_type` (gate, and spliced into the agent
+file path), and `tool_input.model` (gate; any non-empty value allows). No other
+field is read, and the prompt carried in `tool_input` is never logged.
 
 See `design/formats.md` for what these fields look like on the wire and which
 Claude Code version introduced them.
@@ -200,6 +207,39 @@ The README also describes the marker as "session has not already been analysed",
 which reads as once-per-session; it is a concurrency lock with a two-hour stale
 sweep, and a session can be analysed many times.
 
+### 2.3 PreToolUse gate order
+
+`enforce-subagent-model.mjs` is a port of a personal bash hook
+(`~/.claude/hooks/enforce-subagent-model.sh`); the behaviour below is the
+behaviour that hook had. Every gate allows the dispatch; only the final step
+blocks.
+
+| # | Gate | Condition to allow |
+| --- | --- | --- |
+| 1 | Opt-in | `ENFORCE_SUBAGENT_MODEL` is not `1`/`true`. Checked before stdin is read, so the hook is a bare process spawn when off |
+| 2 | Tool name | `tool_name` is neither `Task` nor `Agent` |
+| 3 | Dispatch shape | `tool_input.subagent_type` is empty, **or** `tool_input.model` is non-empty |
+| 4 | Path safety | `subagent_type` contains `/` or starts with `.` |
+| 5 | Agent lookup | no readable file at `<dir>/<t>.md` or `<dir>/<t>/<t>.md`, for `dir` in `${CLAUDE_PROJECT_DIR:-.}/.claude/agents` then `~/.claude/agents`, first hit wins |
+| 6 | Pin | the file's frontmatter has no `model:` key, or its value lower-cases to `inherit` |
+
+Past gate 6 the hook logs one `BLOCK:` line, writes the `BLOCKED:` message to
+stderr, and exits 2.
+
+The pin is read as the first line matching `^model:[ \t]+(\S+)` inside the
+leading `---`/`---` block, with `"` and `'` stripped from the value and a
+trailing `\r` tolerated. A `model:` line after the closing `---` is body text
+and is not a pin. Only the first `---` block counts, and only when it is line 1.
+
+The lookup is a plain path splice, so gate 4 is load-bearing: `subagent_type` is
+unsanitised tool input. Rejecting rather than sanitising means a legitimate agent
+whose name contains `/` is never enforced, which is the fail-open side.
+
+**[OPEN QUESTION FOR THE PORT]** The hook does not read plugin-provided agents
+(`<plugin>/agents/*.md`), only project and personal ones, so a pinned agent that
+ships inside a plugin is never enforced. Decide whether the port widens the
+search.
+
 ---
 
 ## 3. Configuration
@@ -238,6 +278,7 @@ Every other `cfg()` call site is **[UNTESTED]** for precedence.
 | Interactive recommendations | `CLAUDE_WATCHDOG_INTERACTIVE_RECOMMENDATIONS` | `CLAUDE_PLUGIN_OPTION_INTERACTIVE_RECOMMENDATIONS` | `0` | bool |
 | Skip with background tasks | `CLAUDE_WATCHDOG_SKIP_WITH_BACKGROUND_TASKS` | `CLAUDE_PLUGIN_OPTION_SKIP_WITH_BACKGROUND_TASKS` | `1` | bool |
 | Hold input | `CLAUDE_WATCHDOG_HOLD_INPUT` | `CLAUDE_PLUGIN_OPTION_HOLD_INPUT_DURING_ANALYSIS` | `0` | bool |
+| Enforce subagent model | `CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL` | `CLAUDE_PLUGIN_OPTION_ENFORCE_SUBAGENT_MODEL` | `0` | bool |
 | Include rules | `CLAUDE_WATCHDOG_INCLUDE_RULES` | `CLAUDE_PLUGIN_OPTION_INCLUDE_RULES` | `1` | bool |
 | Verbose | `CLAUDE_WATCHDOG_VERBOSE` | `CLAUDE_PLUGIN_OPTION_VERBOSE` | `0` | bool |
 | Legacy exit-2 mode | `CLAUDE_WATCHDOG_LEGACY_HOOK` | `CLAUDE_PLUGIN_OPTION_legacy_hook` | `false` | see below |
@@ -616,9 +657,12 @@ most 20 analysis files survive, newest by mtime. **[UNTESTED]** in the Stop hook
 | UserPromptSubmit | allow, any reason | nothing | 0 |
 | UserPromptSubmit | block | `{"decision":"block","reason":"<hold message>"}`, no trailing newline | 0 |
 | SubagentStop | any | nothing | 0 |
+| PreToolUse | allow, any reason | nothing | 0 |
+| PreToolUse | block | nothing on stdout; the `BLOCKED:` message plus `\n` on **stderr** | **2** |
 
-Exit code 2 in legacy mode is the only non-zero exit any hook produces. Every
-error path in all three hooks is fail-open: the exception is caught, an `ERROR:`
+Legacy mode and a PreToolUse block are the only non-zero exits any hook
+produces; for PreToolUse, exit 2 *is* the block protocol, not an error. Every
+error path in all four hooks is fail-open: the exception is caught, an `ERROR:`
 line is logged, and the process exits 0. Legacy mode is **[UNTESTED]**.
 
 The debug CLIs do use other codes; see section 9.
@@ -647,6 +691,10 @@ The complete set, per hook.
 **Hold hook**, tagged `[hold]`: `RELEASE: hold expired for session=<sid> (<n>s >
 <m>s)`, `RELEASE: user override for session=<sid>`, `HOLD: blocked prompt for
 session=<sid> (age=<n>s)`, `ERROR: unexpected failure: <message>`.
+
+**Enforce hook**, tagged `[model]`: `BLOCK: '<subagent_type>' pinned to <model>,
+dispatch had no explicit model`, `ERROR: unexpected failure: <message>`. Nothing
+is logged on an allow, since the hook runs on every dispatch.
 
 **Persist hook**, tagged `[persist]`: `WROTE: <path> (<n> bytes)`, `SKIP: invalid
 session_id`, `SKIP: empty last_assistant_message for session=<sid>`,

--- a/hooks/enforce-subagent-model.mjs
+++ b/hooks/enforce-subagent-model.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// PreToolUse hook: refuse a Task/Agent dispatch that omits `model` when the
+// agent definition pins one. Exit 2 + stderr is the PreToolUse block protocol;
+// any other exit allows the call.
+//
+// Runs on every Task/Agent dispatch, so: the opt-in check exits before reading
+// stdin, and every path other than the deliberate block fails open (exit 0).
+import { readFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { dumpEvent } from './dump-events.mjs';
+
+process.umask(0o077);
+
+function cfg(watchdogVar, pluginVar, defaultVal) {
+  return process.env[watchdogVar] ?? process.env[pluginVar] ?? defaultVal;
+}
+
+const LOG_FILE = process.env.CLAUDE_WATCHDOG_LOG ?? join(homedir(), '.claude/logs/claude-watchdog.log');
+const ENFORCE = cfg('CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL', 'CLAUDE_PLUGIN_OPTION_ENFORCE_SUBAGENT_MODEL', '0');
+
+function log(msg) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  appendFileSync(LOG_FILE, `[${ts}] [model] ${msg}\n`);
+}
+
+// First `model:` in the leading `---` frontmatter block, quotes stripped.
+function pinnedModel(text) {
+  const lines = text.split('\n').map(l => l.replace(/\r$/, ''));
+  if (lines[0] !== '---') return '';
+  for (const line of lines.slice(1)) {
+    if (line === '---') return '';
+    const m = /^model:[ \t]+(\S+)/.exec(line);
+    if (m) return m[1].replace(/["']/g, '');
+  }
+  return '';
+}
+
+// Project agents shadow personal ones; a bare `<t>.md` shadows `<t>/<t>.md`.
+function readAgentFile(subagentType) {
+  const dirs = [
+    join(process.env.CLAUDE_PROJECT_DIR ?? '.', '.claude/agents'),
+    join(homedir(), '.claude/agents'),
+  ];
+  for (const dir of dirs) {
+    for (const file of [join(dir, `${subagentType}.md`), join(dir, subagentType, `${subagentType}.md`)]) {
+      try {
+        return readFileSync(file, 'utf8');
+      } catch { /* not here, keep looking */ }
+    }
+  }
+  return null;
+}
+
+try {
+  if (ENFORCE !== '1' && ENFORCE !== 'true') process.exit(0);
+
+  mkdirSync(dirname(LOG_FILE), { recursive: true });
+
+  const input = readFileSync(0).slice(0, 65536).toString('utf8');
+  dumpEvent('pre-tool-use', input);
+  const event = JSON.parse(input);
+
+  const toolName = event.tool_name ?? '';
+  if (toolName !== 'Task' && toolName !== 'Agent') process.exit(0);
+
+  const subagentType = event.tool_input?.subagent_type ?? '';
+  const model = event.tool_input?.model ?? '';
+  if (!subagentType || model) process.exit(0);
+
+  // subagent_type is unsanitised tool input and is spliced into a path below.
+  if (subagentType.includes('/') || subagentType.startsWith('.')) process.exit(0);
+
+  const agentText = readAgentFile(subagentType);
+  if (agentText === null) process.exit(0);
+
+  const pinned = pinnedModel(agentText);
+  if (!pinned || pinned.toLowerCase() === 'inherit') process.exit(0);
+
+  log(`BLOCK: '${subagentType}' pinned to ${pinned}, dispatch had no explicit model`);
+  process.stderr.write(`BLOCKED: '${subagentType}' is pinned (model: ${pinned}) but this dispatch has no explicit 'model'. Re-dispatch with model: "${pinned}". A deliberate different model also passes, but it must be explicit.\n`);
+  process.exit(2);
+} catch (err) {
+  try { log(`ERROR: unexpected failure: ${err.message}`); } catch { /* logging itself failed */ }
+  process.exit(0);
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -25,6 +25,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-subagent-model.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "matcher": "session-analyzer",

--- a/justfile
+++ b/justfile
@@ -54,6 +54,10 @@ test-hold:
 test-agent-prompt:
     bash tests/agent-prompt.sh
 
+# PreToolUse pinned-subagent-model hook
+test-enforce-model:
+    bash tests/enforce-model.sh
+
 # Perf budgets (not part of `just test`)
 test-perf:
     bash tests/perf.sh
@@ -100,7 +104,7 @@ test-lifecycle:
 # --- end rewrite/coverage-config --------------------------------------------
 
 # Run all tests
-test: smoke test-cursor test-condense test-persist test-hold test-agent-prompt test-gates test-fixtures test-golden test-config test-lifecycle
+test: smoke test-cursor test-condense test-persist test-hold test-agent-prompt test-enforce-model test-gates test-fixtures test-golden test-config test-lifecycle
 
 # Lint + all tests
 check: lint test

--- a/tests/enforce-model.sh
+++ b/tests/enforce-model.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# The PreToolUse pinned-subagent-model hook.
+#
+# Agent definitions are real .md files under a hermetic $HOME and
+# $CLAUDE_PROJECT_DIR, so the frontmatter reader and the lookup order are
+# exercised end to end rather than stubbed.
+# shellcheck source=tests/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+GHOME="$TMPROOT/home"
+PROJ="$TMPROOT/project"
+HOME_AGENTS="$GHOME/.claude/agents"
+PROJ_AGENTS="$PROJ/.claude/agents"
+mkdir -p "$HOME_AGENTS" "$PROJ_AGENTS"
+LOG="$TMPROOT/log"
+
+base_env() {
+  echo "HOME=$GHOME" "CLAUDE_PROJECT_DIR=$PROJ" "CLAUDE_WATCHDOG_LOG=$LOG"
+}
+
+# enforce <payload> [ENV=VAL ...] - runs with the hermetic env prepended.
+enforce() {
+  local payload="$1"; shift
+  # shellcheck disable=SC2046  # deliberate word splitting of the env list
+  run_enforce "$payload" $(base_env) "$@"
+}
+
+mk_payload() {
+  local tool="$1" subagent="$2" model="${3:-}"
+  jq -n --arg tool "$tool" --arg sa "$subagent" --arg m "$model" \
+    '{hook_event_name:"PreToolUse", tool_name:$tool,
+      tool_input: ({subagent_type:$sa} + (if $m == "" then {} else {model:$m} end))}'
+}
+
+allow() {
+  local name="$1"
+  [ "$ENFORCE_RC" -eq 0 ] || fail "$name" "expected exit 0, got $ENFORCE_RC (stderr: $ENFORCE_ERR)"
+  [ -z "$ENFORCE_ERR" ] || fail "$name" "expected empty stderr, got '$ENFORCE_ERR'"
+  pass "$name"
+}
+
+# Agent fixtures.
+printf -- '---\nname: pinned\nmodel: opus\n---\nbody\n' > "$HOME_AGENTS/pinned.md"
+printf -- '---\nname: inheriting\nmodel: inherit\n---\n' > "$HOME_AGENTS/inheriting.md"
+printf -- '---\nname: shouty\nmodel: INHERIT\n---\n' > "$HOME_AGENTS/shouty.md"
+printf -- '---\nname: unpinned\ndescription: no model key\n---\n' > "$HOME_AGENTS/unpinned.md"
+printf -- '---\nname: quoted\nmodel: "haiku"\n---\n' > "$HOME_AGENTS/quoted.md"
+printf -- '---\r\nname: crlf\r\nmodel: sonnet\r\n---\r\n' > "$HOME_AGENTS/crlf.md"
+printf -- '---\nname: shadowed\nmodel: haiku\n---\n' > "$HOME_AGENTS/shadowed.md"
+printf -- '---\nname: shadowed\nmodel: opus\n---\n' > "$PROJ_AGENTS/shadowed.md"
+mkdir -p "$PROJ_AGENTS/nested"
+printf -- '---\nname: nested\nmodel: sonnet\n---\n' > "$PROJ_AGENTS/nested/nested.md"
+# A `model:` outside the frontmatter block must not be read as a pin.
+printf -- '---\nname: bodyonly\n---\nmodel: opus\n' > "$HOME_AGENTS/bodyonly.md"
+
+# --- Test 1: flag off (the default) -> allow even a pinned agent ---
+enforce "$(mk_payload Agent pinned)"
+allow "default-off-allows"
+
+# --- Test 2: flag on, non-dispatch tool -> allow ---
+enforce "$(mk_payload Read pinned)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+allow "other-tool-allows"
+
+# --- Test 3: flag on, pinned agent, no model -> block with the exact message ---
+expected="BLOCKED: 'pinned' is pinned (model: opus) but this dispatch has no explicit 'model'. Re-dispatch with model: \"opus\". A deliberate different model also passes, but it must be explicit."
+enforce "$(mk_payload Agent pinned)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+[ "$ENFORCE_RC" -eq 2 ] || fail "pinned-blocks" "expected exit 2, got $ENFORCE_RC"
+[ "$ENFORCE_ERR" = "$expected" ] || fail "pinned-blocks-message" "got '$ENFORCE_ERR'"
+[ -z "$ENFORCE_OUT" ] || fail "pinned-blocks-stdout" "expected empty stdout, got '$ENFORCE_OUT'"
+grep -q "BLOCK: 'pinned' pinned to opus" "$LOG" || fail "pinned-blocks-log" "no BLOCK log line"
+pass "pinned-blocks"
+
+# --- Test 4: Task is enforced the same as Agent ---
+enforce "$(mk_payload Task pinned)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+[ "$ENFORCE_RC" -eq 2 ] || fail "task-blocks" "expected exit 2, got $ENFORCE_RC"
+pass "task-tool-blocks"
+
+# --- Test 5: the plugin-config variable enables it too ---
+enforce "$(mk_payload Agent pinned)" CLAUDE_PLUGIN_OPTION_ENFORCE_SUBAGENT_MODEL=true
+[ "$ENFORCE_RC" -eq 2 ] || fail "plugin-option" "expected exit 2, got $ENFORCE_RC"
+pass "plugin-option-enables"
+
+# --- Test 6: explicit model -> allow, even a different one ---
+enforce "$(mk_payload Agent pinned haiku)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+allow "explicit-model-allows"
+
+# --- Test 7: inherit / INHERIT / no model key -> allow ---
+for agent in inheriting shouty unpinned bodyonly; do
+  enforce "$(mk_payload Agent "$agent")" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+  allow "unpinned-allows-$agent"
+done
+
+# --- Test 8: no subagent_type, or an unknown one -> allow ---
+enforce "$(mk_payload Agent "")" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+allow "no-subagent-type-allows"
+enforce "$(mk_payload Agent no-such-agent)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+allow "unknown-agent-allows"
+
+# --- Test 9: path-ish subagent_type is refused before any lookup ---
+printf -- '---\nname: evil\nmodel: opus\n---\n' > "$TMPROOT/evil.md"
+printf -- '---\nname: hidden\nmodel: opus\n---\n' > "$HOME_AGENTS/.hidden.md"
+for evil in "../evil" "nested/nested" ".hidden"; do
+  enforce "$(mk_payload Agent "$evil")" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+  allow "path-traversal-allows-$evil"
+done
+
+# --- Test 10: project agents shadow personal ones ---
+enforce "$(mk_payload Agent shadowed)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+[ "$ENFORCE_RC" -eq 2 ] || fail "shadowing" "expected exit 2, got $ENFORCE_RC"
+case "$ENFORCE_ERR" in
+  *"model: opus"*) ;;
+  *) fail "shadowing" "project agent should win, got '$ENFORCE_ERR'" ;;
+esac
+pass "project-agent-shadows-home"
+
+# --- Test 11: <agent>/<agent>.md is found ---
+enforce "$(mk_payload Agent nested)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+[ "$ENFORCE_RC" -eq 2 ] || fail "nested-layout" "expected exit 2, got $ENFORCE_RC"
+pass "nested-agent-layout"
+
+# --- Test 12: quoted and CRLF frontmatter parse to a bare model name ---
+enforce "$(mk_payload Agent quoted)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+case "$ENFORCE_ERR" in *"model: haiku)"*) ;; *) fail "quoted" "got '$ENFORCE_ERR'" ;; esac
+pass "quoted-model-parses"
+enforce "$(mk_payload Agent crlf)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+case "$ENFORCE_ERR" in *"model: sonnet)"*) ;; *) fail "crlf" "got '$ENFORCE_ERR'" ;; esac
+pass "crlf-frontmatter-parses"
+
+# --- Test 13: fail-open on garbage stdin ---
+enforce "not json" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
+[ "$ENFORCE_RC" -eq 0 ] || fail "fail-open" "expected exit 0, got $ENFORCE_RC"
+pass "fail-open"
+
+echo "All enforce-model tests passed."

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -27,6 +27,7 @@ done < <(env)
 : "${HOOK_STOP:=node hooks/session-analysis.mjs}"
 : "${HOOK_HOLD:=node hooks/hold-input.mjs}"
 : "${HOOK_PERSIST:=node hooks/persist-analysis.mjs}"
+: "${HOOK_ENFORCE:=node hooks/enforce-subagent-model.mjs}"
 # Debug CLI: `<binary> condense <jsonl> [bytes]` / `<binary> extract <jsonl>`.
 # See tests/CONDENSE-CLI.md - this is a supported interface, not an internal.
 : "${HOOK_CONDENSE:=node hooks/condense.mjs}"
@@ -35,6 +36,7 @@ read -r -a HOOK_STOP_CMD <<< "$HOOK_STOP"
 read -r -a HOOK_HOLD_CMD <<< "$HOOK_HOLD"
 read -r -a HOOK_PERSIST_CMD <<< "$HOOK_PERSIST"
 read -r -a HOOK_CONDENSE_CMD <<< "$HOOK_CONDENSE"
+read -r -a HOOK_ENFORCE_CMD <<< "$HOOK_ENFORCE"
 
 FIXTURE="${FIXTURE:-tests/fixtures/midturn-session.jsonl}"
 
@@ -71,6 +73,20 @@ run_persist() {
 }
 
 run_condense() { "${HOOK_CONDENSE_CMD[@]}" "$@"; }
+
+# The PreToolUse block protocol is stderr + exit 2, so ENFORCE_ERR carries the
+# assertion and ENFORCE_OUT exists only to prove stdout stays empty.
+ENFORCE_OUT=""; ENFORCE_ERR=""; ENFORCE_RC=0
+run_enforce() {
+  local payload="$1"; shift
+  local errfile; errfile=$(mktemp)
+  ENFORCE_RC=0
+  # shellcheck disable=SC2034  # read by the sourcing test scripts
+  ENFORCE_OUT=$(printf '%s' "$payload" | env ${1+"$@"} "${HOOK_ENFORCE_CMD[@]}" 2>"$errfile") || ENFORCE_RC=$?
+  # shellcheck disable=SC2034  # read by the sourcing test scripts
+  ENFORCE_ERR=$(cat "$errfile")
+  rm -f "$errfile"
+}
 
 # Classify a Stop-hook result by its wire protocol: "analyze this session" is a
 # JSON `decision:block` on stdout with exit 0 (BLOCK); any other clean exit is a


### PR DESCRIPTION
Adds a fourth hook: a `PreToolUse` gate that blocks a `Task`/`Agent` dispatch naming an agent whose frontmatter pins a `model:`, when the dispatch itself passes no explicit `model`.

Claude Code honours the pin only in that case, so any explicit model silently wins over it. The block makes the override deliberate: re-dispatching with the pinned model passes, and so does re-dispatching with a different one.

**Off by default.** `enforce_subagent_model` / `CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL`, checked before stdin is read, so the hook is a bare process spawn for anyone who leaves it off. Existing users see no change.

The block is exit 2 + stderr - the PreToolUse protocol, supported on every Claude Code version, and unrelated to the Stop hook's stdout-JSON/legacy split. Every other path exits 0, including a parse failure.

This is a port of a personal bash hook, so behaviour is preserved rather than redesigned: project agents shadow personal ones, `<t>.md` shadows `<t>/<t>.md`, the first `model:` in the leading `---` block wins with quotes stripped and CRLF tolerated, `inherit` and unpinned agents are never enforced, and a `subagent_type` containing `/` or starting with `.` is refused before any file read (it is unsanitised tool input spliced into a path).

One thing worth a look: the lookup does not search plugin-bundled agents (`<plugin>/agents/*.md`), so a pinned agent shipped by a plugin is never enforced. Inherited from the bash version, flagged as an open question in `design/contract.md` §2.3. WDYT - widen it here, or leave it?

<details>
<summary>Tests</summary>

`tests/enforce-model.sh`, 20 assertions, hermetic `$HOME` and `$CLAUDE_PROJECT_DIR` with real agent `.md` files on disk. Covers the default-off path, both config variables, block message byte-exactness, `inherit`/`INHERIT`/no-key/body-only, shadowing, nested layout, quoted and CRLF frontmatter, the three path-ish subagent types, and fail-open on garbage stdin.

Wired through `HOOK_ENFORCE` in `tests/lib.sh`, so the suite stays implementation-agnostic. `just check` green, no pre-existing test changed.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkaBzcKa3hEuvsGfyZWtNC
