### PR TITLE
chore(reference): refresh claude-code snapshot to v2.1.263

### DIFF
--- a/design/reference-snapshot.md
+++ b/design/reference-snapshot.md
@@ -1,0 +1,23 @@
+# reference/claude-code snapshot
+
+`reference/claude-code/` is a local, gitignored mirror of
+[anthropics/claude-code](https://github.com/anthropics/claude-code), used for
+grepping hook payload shapes, agent/skill frontmatter fields, and plugin
+examples without a network fetch. It is not part of the repo - nothing under
+`reference/` is tracked or shipped.
+
+It is a point-in-time snapshot, currently at tag `v2.1.263`, refreshed
+2026-09-07. It is **not** authoritative: live docs at
+[docs.claude.com](https://docs.claude.com) win on any disagreement, and the
+installed CLI (`claude --version`) is the ground truth for current behavior.
+
+Refresh it with:
+
+```
+just refresh-reference
+```
+
+This clones upstream at its latest release tag and mirrors it into
+`reference/claude-code/` (excluding `.git` and `demo.gif`), creating the
+directory if it doesn't exist yet. It prints the tag it landed on - update the
+version/date above by hand afterward.

--- a/justfile
+++ b/justfile
@@ -211,3 +211,17 @@ test-gates:
     bash tests/gates.sh
 
 # --- end rewrite/coverage-gates ---------------------------------------------
+
+# Refresh the local, gitignored reference/claude-code mirror to the latest upstream release tag
+refresh-reference:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp=$(mktemp -d)
+    git clone --quiet https://github.com/anthropics/claude-code "$tmp/claude-code"
+    tag=$(git -C "$tmp/claude-code" describe --tags --abbrev=0)
+    git -C "$tmp/claude-code" checkout --quiet "$tag"
+    rm -rf reference/claude-code
+    mkdir -p reference/claude-code
+    rsync -a --exclude='.git' --exclude='demo.gif' "$tmp/claude-code"/ reference/claude-code/
+    rm -rf "$tmp"
+    echo "Refreshed reference/claude-code to ${tag}. Update the version/date in design/reference-snapshot.md."


### PR DESCRIPTION
`reference/claude-code` stays gitignored, exactly as on main - it's a local working mirror, not repo content. Nothing under `reference/` is tracked.

Documents it instead in `design/reference-snapshot.md`: what the directory is, that it's a local point-in-time mirror (currently `v2.1.263`, refreshed 2026-09-07), that live docs.claude.com wins on any disagreement, and how to refresh it. Adds `just refresh-reference` to rebuild the mirror (creates the directory if missing).

The local mirror was refreshed to v2.1.263 on disk during this work; it isn't committed. 122 releases of hook/frontmatter changes landed in that gap - none fixed here (out of scope, other stations own `hooks/`/`agents/`). Follow-up: #42.

`just test`/`just lint` pass.

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJhHmaRVNscv8ryni37ngu