### PR TITLE
fix: unrestrict analyzer Bash grant, tighten output-format rules

### DIFF
--- a/agents/session-analyzer.md
+++ b/agents/session-analyzer.md
@@ -8,11 +8,14 @@ description: >
 model: sonnet
 effort: medium
 maxTurns: 12
-tools: Read, Bash(git diff:*, git log:*, git status:*), Grep, Glob
+tools: Read, Bash, Grep, Glob
 color: yellow
 ---
 
 You are a critical session analyst reviewing one slice of a Claude Code session.
+
+## Bash is read-only
+`tools:` frontmatter cannot scope Bash to a command pattern - grants the whole tool. You still MUST treat it as read-only: git inspection and file inspection only (`git diff`, `git log`, `git status`, `git show`, `cat`, `ls`, `grep`, `find`, `head`, `tail`). `git show` is expected constantly - by Stop time most work is already committed, and it is often the only way to see a committed hunk. Never run builds, tests, linters, or any command that changes repo or filesystem state.
 
 ## Inputs (from the spawn prompt)
 - Condensed transcript path and working directory.
@@ -46,9 +49,15 @@ You are a critical session analyst reviewing one slice of a Claude Code session.
 Slice rule: judge only the work in this slice. Missing context from before the slice is not a failure. If a previous analysis is provided, do not repeat its findings.
 
 ## Output
+Your final message MUST begin with `### Goals` - no preamble, no "Confirmed:", no summary of what you checked or read first. The first characters you emit are `### Goals`.
+
 `### Goals` (mandatory, 2-4 sentences): were the asks in this slice achieved, cross-checked against the diff.
 
-`### Efficiency`, `### Quality`, `### Compliance` are conditional: emit only with a concrete finding, otherwise omit the section entirely (no "nothing to report").
+Fast path: no findings clear the signal threshold below -> Goals, then `### Recommendations` with `none`, stop. Do not open a section to write that it found nothing.
+
+Signal threshold: a finding must have caused a wrong result, wasted a meaningful amount of work, broke an instruction, or would recur. Do not report style nits, hypothetical risks, things the user can already see in the diff, or anything you would not interrupt a colleague for. Not recommending anything is the expected outcome for a normal session, not a failure to analyse.
+
+`### Efficiency`, `### Quality`, `### Compliance` are conditional: emit only with a concrete finding, otherwise omit the heading entirely. There is no correct way to say a conditional section found nothing - not "No compliance issues found", not "solid verification", not "good practice, not a flaw". If you catch yourself writing one of those, delete the heading instead.
 - Efficiency: detours, repeated failures, wasted effort.
 - Quality: sloppy, hallucinated, or cargo-culted code or claims.
 - Compliance: instructions ignored, trade-offs not flagged, user concerns handwaved, agreed too easily. Re-check mid-turn lines before calling anything unrequested.
@@ -59,11 +68,9 @@ Verification rule: before calling output hallucinated or unverified, look for `T
 
 `### Recommendations` (mandatory): 1-3 items or the literal `none`. Only things the user can act on, format `**Title** [code|instruction|process]: one sentence naming the file or rule`. [code] = repo change, [instruction] = rule to add to CLAUDE.md/rules to prevent recurrence, [process] = workflow change. Praise or "keep doing X" is not a recommendation.
 
-Signal threshold: a finding must have caused a wrong result, wasted a meaningful amount of work, broke an instruction, or would recur. Do not report style nits, hypothetical risks, things the user can already see in the diff, or anything you would not interrupt a colleague for. Not recommending anything is the expected outcome for a normal session, not a failure to analyse.
-
-Fast path: no findings that clear the threshold -> Goals, then `### Recommendations` with `none`, stop.
-
 Rules:
 - Be direct and critical, not flattering. Critical means accurate, not fault-finding.
 - Only comment on what actually happened, not hypotheticals.
+- Every heading is `###`, never `##` or any other level.
+- Plain hyphens only. Never use an em dash (—) or en dash (–) anywhere in the output.
 - ~40 words per finding, hard max 350 words total.

--- a/skills/analyze-session/SKILL.md
+++ b/skills/analyze-session/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: When the user wants a critical review of the current session's goal
 user-invocable: true
 model: sonnet
 effort: high
-allowed-tools: Read, Bash(git diff:*, git log:*, git status:*), Grep, Glob
+allowed-tools: Read, Bash, Grep, Glob
 ---
 
 You are a critical session analyst reviewing the current Claude Code session.
@@ -17,6 +17,9 @@ condensed transcript file, so it carries no transcript legend and no slice
 framing - there is no delta, no touched-file list, and no previous analysis to
 avoid repeating.
 
+## Bash is read-only
+`allowed-tools` cannot scope Bash to a command pattern - it grants the whole tool. Treat it as read-only: git inspection and file inspection only (`git diff`, `git log`, `git status`, `git show`, `cat`, `ls`, `grep`, `find`, `head`, `tail`). `git show` is expected constantly - most work is already committed by the time this runs. Never run builds, tests, linters, or any command that changes repo or filesystem state.
+
 ## Workflow
 1. Read the conversation so far to understand what was asked and attempted.
 2. If the project has instruction files (`CLAUDE.md`, `.claude/rules/*.md`, project first, then `~/.claude`), read them. They are the reference for Compliance.
@@ -25,9 +28,15 @@ avoid repeating.
 5. Cross-reference the asks against the diff.
 
 ## Output
+Your final message MUST begin with `### Goals` - no preamble, no "Confirmed:", no summary of what you checked or read first. The first characters you emit are `### Goals`.
+
 `### Goals` (mandatory, 2-4 sentences): were the user's asks achieved, cross-checked against the diff.
 
-`### Efficiency`, `### Quality`, `### Compliance` are conditional: emit only with a concrete finding, otherwise omit the section entirely (no "nothing to report").
+Fast path: no findings clear the signal threshold below -> Goals, then `### Recommendations` with `none`, stop. Do not open a section to write that it found nothing.
+
+Signal threshold: a finding must have caused a wrong result, wasted a meaningful amount of work, broke an instruction, or would recur. Do not report style nits, hypothetical risks, things the user can already see in the diff, or anything you would not interrupt a colleague for. Not recommending anything is the expected outcome for a normal session, not a failure to analyse.
+
+`### Efficiency`, `### Quality`, `### Compliance` are conditional: emit only with a concrete finding, otherwise omit the heading entirely. There is no correct way to say a conditional section found nothing - not "No compliance issues found", not "solid verification", not "good practice, not a flaw". If you catch yourself writing one of those, delete the heading instead.
 - Efficiency: detours, repeated failures, wasted effort.
 - Quality: sloppy, hallucinated, or cargo-culted code or claims.
 - Compliance: instructions ignored, trade-offs not flagged, user concerns handwaved, agreed too easily. Re-check messages the user sent mid-turn while Claude was working before calling anything unrequested - that is where corrections and extra asks arrive.
@@ -38,11 +47,9 @@ Verification rule: before calling output hallucinated or unverified, look for to
 
 `### Recommendations` (mandatory): 1-3 items or the literal `none`. Only things the user can act on, format `**Title** [code|instruction|process]: one sentence naming the file or rule`. [code] = repo change, [instruction] = rule to add to CLAUDE.md/rules to prevent recurrence, [process] = workflow change. Praise or "keep doing X" is not a recommendation.
 
-Signal threshold: a finding must have caused a wrong result, wasted a meaningful amount of work, broke an instruction, or would recur. Do not report style nits, hypothetical risks, things the user can already see in the diff, or anything you would not interrupt a colleague for. Not recommending anything is the expected outcome for a normal session, not a failure to analyse.
-
-Fast path: no findings that clear the threshold -> Goals, then `### Recommendations` with `none`, stop.
-
 Rules:
 - Be direct and critical, not flattering. Critical means accurate, not fault-finding.
 - Only comment on what actually happened, not hypotheticals.
+- Every heading is `###`, never `##` or any other level.
+- Plain hyphens only. Never use an em dash (—) or en dash (–) anywhere in the output.
 - ~40 words per finding, hard max 350 words total.

--- a/tests/agent-prompt.sh
+++ b/tests/agent-prompt.sh
@@ -69,4 +69,43 @@ elif [ "$(grep -cF "$ON_DISK" "$f3")" != "1" ]; then
 else
   echo "PASS: no duplicate when the final message already reached the transcript"
 fi
+
+# --- Issue #34: Bash grant must not use an unsupported permission-rule pattern ---
+skill="skills/analyze-session/SKILL.md"
+check_no_bash_pattern() { # check_no_bash_pattern <file> <field>
+  local file="$1" field="$2"
+  local line; line=$(grep -m1 "^${field}:" "$file")
+  if echo "$line" | grep -q 'Bash('; then
+    echo "FAIL: $file $field grants Bash with a permission-rule pattern, which frontmatter does not honour: $line" >&2; rc=1
+  elif ! echo "$line" | grep -qE '(^|, )Bash(,|$)'; then
+    echo "FAIL: $file $field does not grant plain Bash: $line" >&2; rc=1
+  else
+    echo "PASS: $file $field grants plain Bash, no pattern"
+  fi
+}
+check_no_bash_pattern "$prompt" "tools"
+check_no_bash_pattern "$skill" "allowed-tools"
+
+check_rule_present() { # check_rule_present <file> <needle> <description>
+  if grep -qF "$2" "$1"; then echo "PASS: $1 has $3"; else echo "FAIL: $1 missing $3" >&2; rc=1; fi
+}
+for f in "$prompt" "$skill"; do
+  check_rule_present "$f" "git show" "an explicit git show mention"
+  check_rule_present "$f" 'MUST begin with `### Goals`' "the no-preamble rule"
+  check_rule_present "$f" "delete the heading instead" "the conditional-section negative example"
+  check_rule_present "$f" "Never use an em dash" "the em/en dash punctuation rule"
+  check_rule_present "$f" 'Every heading is `###`' "the heading-level rule"
+done
+
+# --- Twin parity: the ## Output section must have the same headings, in the
+# same order, in both files. Prose differs deliberately (transcript vs. live
+# conversation wording); structure must not.
+extract_headings() { sed -n '/^## Output$/,/^Rules:$/p' "$1" | grep -oE '^(###[^(]*|- [A-Za-z]+:)'; }
+if diff -q <(extract_headings "$prompt") <(extract_headings "$skill") > /dev/null; then
+  echo "PASS: agent and skill Output section structure is in step"
+else
+  diff <(extract_headings "$prompt") <(extract_headings "$skill") >&2
+  echo "FAIL: agent and skill Output section structure has drifted" >&2; rc=1
+fi
+
 exit $rc

--- a/tests/agent-prompt.sh
+++ b/tests/agent-prompt.sh
@@ -91,10 +91,10 @@ check_rule_present() { # check_rule_present <file> <needle> <description>
 }
 for f in "$prompt" "$skill"; do
   check_rule_present "$f" "git show" "an explicit git show mention"
-  check_rule_present "$f" 'MUST begin with `### Goals`' "the no-preamble rule"
+  check_rule_present "$f" "MUST begin with \`### Goals\`" "the no-preamble rule"
   check_rule_present "$f" "delete the heading instead" "the conditional-section negative example"
   check_rule_present "$f" "Never use an em dash" "the em/en dash punctuation rule"
-  check_rule_present "$f" 'Every heading is `###`' "the heading-level rule"
+  check_rule_present "$f" "Every heading is \`###\`" "the heading-level rule"
 done
 
 # --- Twin parity: the ## Output section must have the same headings, in the


### PR DESCRIPTION
Fixes #34 and #38 in `agents/session-analyzer.md` and its twin `skills/analyze-session/SKILL.md`. Scope is those two files plus `tests/agent-prompt.sh` - no hook JS touched.

**#34 - Bash allowlist not enforced.** `tools: Read, Bash(git diff:*, git log:*, git status:*), Grep, Glob` looked scoped but isn't: I confirmed against the live sub-agents docs (code.claude.com/docs/en/sub-agents) that `tools:` accepts only exact tool names and MCP server patterns, nothing else - `Bash(...)` patterns are silently ignored and the grant is just `Bash`. Went with option 1 from the issue: plain `Bash` in frontmatter, plus a hard read-only rule in the prompt body (git/file inspection only, no builds/tests/linters). `git show` is called out explicitly and allowed, since the analyzer needs it constantly by Stop time when most work is already committed.

**#38 - output-format drift.** Across the 43 measured runs: preamble before `### Goals`, conditional sections emitting praise text instead of being omitted, and em-dash usage. Added:
- A rule that the final message's first characters must be `### Goals` - no preamble.
- A negative example for the conditional-section rule (the exact "No compliance issues found" / "solid verification" phrasings that showed up in the evidence).
- A plain-hyphen punctuation rule (no em/en dashes).
- Explicit `###`-only heading enforcement.
- Moved the fast path above the conditional-section definitions, per the issue's suggestion, so it's read first.

Applied identically to both twins so they stay in step.

**Tests.** Extended `tests/agent-prompt.sh` with mechanically-checkable assertions: no `Bash(...)` pattern in either frontmatter, presence of each new rule text in both files, and structural parity (headings/bullet labels, not prose) between the agent and skill `## Output` sections - the deliberate prose differences (transcript vs. live-conversation wording) are intentionally excluded from that diff.

<details>
<summary>Test output</summary>

`just test` passes in full, including the golden-file comparisons (unchanged - no hook JS was touched, so no `just golden-regen` was needed).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YPDtY4AW4JugHpicdLmpq