### PR TITLE
fix: match plugin-scoped agent_type in persist-analysis hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Run a short session and end Claude's turn. You should see output like:
 | --- | --- | --- |
 | Stop hook | `hooks/session-analysis.mjs` | Preprocesses the transcript, triggers the analyzer |
 | Condenser | `hooks/condense.mjs` | Turns the raw JSONL into the condensed transcript, within a byte budget |
-| SubagentStop hook | `hooks/persist-analysis.mjs` | Persists the analyzer's output to disk (no UI noise) |
+| SubagentStop hook | `hooks/persist-analysis.mjs` | Persists the analyzer's output to disk and echoes the save path |
 | UserPromptSubmit hook | `hooks/hold-input.mjs` | Optionally holds new prompts while an analysis is in flight |
 | PreToolUse hook | `hooks/enforce-subagent-model.mjs` | Optionally blocks a `Task`/`Agent` dispatch that ignores an agent's pinned model |
 | Subagent | `agents/session-analyzer.md` | Reads the transcript + `git diff`, writes the review |
@@ -208,7 +208,7 @@ Don't want to wait for Claude to stop? Run `/analyze-session` any time during a 
 3. `condense.mjs` filters the JSONL transcript down to user text, assistant text, tool calls, and tool results, keeps the last ~50 KB, and writes it to `${CLAUDE_PLUGIN_DATA}/sessions/condensed-<session-id>.txt` (owner-only permissions; falls back to `~/.claude/tmp/claude-watchdog/sessions/` when not running as an installed plugin). When **Store transcripts in project directory** is enabled, files are written to `<project>/.claude/tmp/claude-watchdog/sessions/` instead — this keeps them inside the project directory so Claude Code's `auto` mode doesn't prompt for Read permission. The project directory is the nearest ancestor of the session's cwd holding `.git` or `.claude`, so a turn that ends with the shell inside a subdirectory still writes to one place per project. Files older than 2 hours are cleaned up automatically in both locations.
 4. It writes `{"decision": "block", "reason": ...}` to stdout and exits `0`. The reason instructs Claude to spawn the `session-analyzer` subagent pointed at that file. Setting `CLAUDE_WATCHDOG_LEGACY_HOOK=true` opts back into the old behaviour - the same instruction on stderr with exit code `2` - for hosts that do not honour the JSON decision.
 5. The subagent reads the condensed transcript, runs `git diff` / `git log` in the working directory, and produces the structured review — all inside your current Claude Code session, using the model you're already authenticated with.
-6. When the subagent finishes, Claude Code fires the `SubagentStop` hook. `persist-analysis.mjs` reads the subagent's final message from the event payload and writes it to `~/.claude/logs/claude-watchdog-analyses/` — so the subagent itself doesn't have to call `Write`, keeping the UI clean.
+6. When the subagent finishes, Claude Code fires the `SubagentStop` hook. `persist-analysis.mjs` reads the subagent's final message from the event payload and writes it to `~/.claude/logs/claude-watchdog-analyses/` — so the subagent itself doesn't have to call `Write` — then prints `Analysis saved to: <path>` on stdout so the save location shows up in the transcript.
 
 ### What the condensed transcript looks like
 

--- a/design/backlog.md
+++ b/design/backlog.md
@@ -31,17 +31,13 @@ not here.
 
 ## MEDIUM PRIORITY
 
-### 3. Confirm analysis save path to the user
+### 3. ~~Confirm analysis save path to the user~~ — done
 
-**Problem:** The SubagentStop hook persists analyses silently. Users never see
-where the file was saved and have no way to find it after the session ends.
-
-**Fix:** Have `hooks/persist-analysis.sh` output the save path on stdout
-(exit 0) so it appears in the transcript, e.g.:
-
-```
-Analysis saved to: ~/.claude/logs/claude-watchdog-analyses/<session>-<ts>.md
-```
+**Status: done**, alongside the agent_type fix (#33): `persist-analysis.mjs`
+was silently failing to match plugin-scoped `agent_type` values, so this item
+was blocked on that bug rather than unimplemented. Now fixed:
+`persist-analysis.mjs` prints `Analysis saved to: <path>` on stdout after a
+successful write.
 
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -39,7 +39,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "session-analyzer",
+        "matcher": "^claude-watchdog:session-analyzer$",
         "hooks": [
           {
             "type": "command",

--- a/hooks/persist-analysis.mjs
+++ b/hooks/persist-analysis.mjs
@@ -34,7 +34,11 @@ try {
   const sessionId = event.session_id ?? '';
   const message = event.last_assistant_message ?? '';
 
-  if (agentType !== 'session-analyzer') process.exit(0);
+  // Plugin-scoped dispatches report agent_type as "<plugin>:session-analyzer".
+  if (!/(^|:)session-analyzer$/.test(agentType)) {
+    log(`SKIP: agent_type '${agentType}' does not match session-analyzer`);
+    process.exit(0);
+  }
 
   if (!/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
     log('SKIP: invalid session_id');
@@ -56,6 +60,7 @@ try {
 
   const size = Buffer.byteLength(message + '\n', 'utf8');
   log(`WROTE: ${outputFile} (${size} bytes)`);
+  console.log(`Analysis saved to: ${outputFile}`);
 
   const files = readdirSync(ANALYSES_DIR)
     .filter(f => f.endsWith('.md'))

--- a/tests/persist.sh
+++ b/tests/persist.sh
@@ -21,6 +21,10 @@ out=$(ls "$CLAUDE_WATCHDOG_ANALYSES_DIR"/${sid1}-*.md 2>/dev/null | head -1)
 grep -q "### Goals" "$out" || fail "analyzer-content" "file missing content"
 pass "analyzer-writes"
 
+# --- Test 1b: save path is echoed to stdout so the user sees where it landed ---
+echo "$PERSIST_OUT" | grep -q "Analysis saved to: $out" || fail "save-path-echoed" "stdout missing save path"
+pass "save-path-echoed"
+
 # --- Test 2: other subagent types are ignored ---
 sid2="persist-t2-$$"
 run_persist "$(jq -n --arg sid "$sid2" --arg msg "ignored" \
@@ -61,5 +65,24 @@ run_persist "$(jq -n --arg sid "$sid6" \
   '{session_id:$sid, agent_type:"session-analyzer", last_assistant_message:""}')"
 [ ! -f "$SESSIONS/pending-${sid6}" ] || fail "pending-cleared-empty" "pending sentinel not removed on empty message"
 pass "pending-cleared-empty-message"
+
+# --- Test 7: plugin-scoped agent_type is accepted ---
+sid7="persist-t7-$$"
+run_persist "$(jq -n --arg sid "$sid7" --arg msg $'### Goals\nScoped analysis.' \
+  '{session_id:$sid, agent_type:"claude-watchdog:session-analyzer", last_assistant_message:$msg}')"
+out=$(ls "$CLAUDE_WATCHDOG_ANALYSES_DIR"/${sid7}-*.md 2>/dev/null | head -1)
+[ -n "$out" ] || fail "scoped-agent-type" "no analysis file written for scoped agent_type"
+pass "scoped-agent-type"
+
+# --- Test 8: non-matching agent_type is skipped and logged with the observed value ---
+sid8="persist-t8-$$"
+run_persist "$(jq -n --arg sid "$sid8" --arg msg "ignored" \
+  '{session_id:$sid, agent_type:"general-purpose", last_assistant_message:$msg}')"
+if ls "$CLAUDE_WATCHDOG_ANALYSES_DIR"/${sid8}-*.md >/dev/null 2>&1; then
+  fail "non-matching-agent-type" "wrote file for non-matching agent_type"
+fi
+grep -q "SKIP: agent_type 'general-purpose' does not match session-analyzer" "$CLAUDE_WATCHDOG_LOG" \
+  || fail "non-matching-agent-type-log" "no skip log for non-matching agent_type"
+pass "non-matching-agent-type-logged"
 
 echo "--- all persist tests passed ---"

--- a/tests/persist.sh
+++ b/tests/persist.sh
@@ -70,7 +70,7 @@ pass "pending-cleared-empty-message"
 sid7="persist-t7-$$"
 run_persist "$(jq -n --arg sid "$sid7" --arg msg $'### Goals\nScoped analysis.' \
   '{session_id:$sid, agent_type:"claude-watchdog:session-analyzer", last_assistant_message:$msg}')"
-out=$(ls "$CLAUDE_WATCHDOG_ANALYSES_DIR"/${sid7}-*.md 2>/dev/null | head -1)
+out=$(find "$CLAUDE_WATCHDOG_ANALYSES_DIR" -maxdepth 1 -name "${sid7}-*.md" -print -quit 2>/dev/null)
 [ -n "$out" ] || fail "scoped-agent-type" "no analysis file written for scoped agent_type"
 pass "scoped-agent-type"
 


### PR DESCRIPTION
persist-analysis.mjs has been dead since mid-August: Claude Code now sends `agent_type` as `claude-watchdog:session-analyzer` for plugin agents, but the hook compared against the bare `session-analyzer` and exited silently. No analysis has been saved, `latestAnalysis()` never finds a file, and the `Previous analysis` continuation line has been missing from every prompt.

**Fix:**
- Accept both forms with `/(^|:)session-analyzer$/`.
- Anchor the `hooks.json` SubagentStop matcher to `^claude-watchdog:session-analyzer$`.
- Log the skip (with the observed `agent_type`) when it doesn't match, instead of exiting silently, so this failure class is visible in the watchdog log next time.

**Also folded in #41 (small, as suggested there):** since backlog item 3 ("confirm analysis save path to the user") was blocked on this exact bug, I implemented it alongside the fix rather than as a separate PR — it's a two-line addition. `persist-analysis.mjs` now echoes `Analysis saved to: <path>` on stdout after a successful write, and I updated `design/backlog.md` item 3 to reflect it's done.

Tests added to `tests/persist.sh` (written failing first, then the fix): scoped `agent_type` writes a file, the bare form still works (already covered), a non-matching `agent_type` produces the skip log line, and the save-path stdout line is asserted.

Left out: I didn't touch `session-analysis.mjs` or `agents/session-analyzer.md` — those are owned by other stations and weren't in scope for #33/#41.

<details>
<summary>Test evidence</summary>

```
just test
...
bash tests/persist.sh
PASS: analyzer-writes
PASS: save-path-echoed
PASS: other-agent-ignored
PASS: empty-message
PASS: invalid-session-id
PASS: pending-cleared
PASS: pending-cleared-empty-message
PASS: scoped-agent-type
PASS: non-matching-agent-type-logged
--- all persist tests passed ---
...
EXIT: 0, 0 FAIL lines across full suite (smoke, cursor, condense, persist, hold, agent-prompt, enforce-model, gates, fixtures, golden, config, lifecycle)
```

</details>

Fixes #33
Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkdVj37A9wwV2nM59xJwhu