### PR TITLE
fix: skip model enforcement under CLAUDE_CODE_SUBAGENT_MODEL_FORCE, document native Agent(model:) rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ under `$CLAUDE_PROJECT_DIR/.claude/agents`, then `~/.claude/agents`. An agent wi
 no `model:` key, or `model: inherit`, is never enforced. Every other path allows the
 dispatch, so a malformed definition or an unreadable directory cannot wedge Claude.
 
+Claude Code >= 2.1.178 also accepts `Agent(model:opus)` as a native permission rule.
+That denies (or allows) a specific model *value* and complements this hook, which
+blocks a *missing* model - the native syntax cannot express "parameter absent". The
+hook is a no-op when `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` is set, since that overrides
+every per-spawn and definition model anyway.
+
 You can also create a `.claude-watchdog-skip` file to disable the hook for a project. The hook looks for it in the session's working directory, so put it at the directory you start Claude Code from:
 
 ```bash

--- a/hooks/enforce-subagent-model.mjs
+++ b/hooks/enforce-subagent-model.mjs
@@ -18,6 +18,10 @@ function cfg(watchdogVar, pluginVar, defaultVal) {
 
 const LOG_FILE = process.env.CLAUDE_WATCHDOG_LOG ?? join(homedir(), '.claude/logs/claude-watchdog.log');
 const ENFORCE = cfg('CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL', 'CLAUDE_PLUGIN_OPTION_ENFORCE_SUBAGENT_MODEL', '0');
+// CLAUDE_CODE_SUBAGENT_MODEL_FORCE (Claude Code 2.1.257+) overrides both the
+// per-spawn and the definition model, so a missing `model` changes nothing.
+const FORCE = process.env.CLAUDE_CODE_SUBAGENT_MODEL_FORCE ?? '';
+const FORCED = FORCE !== '' && FORCE !== '0' && FORCE.toLowerCase() !== 'false';
 
 function log(msg) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -54,6 +58,7 @@ function readAgentFile(subagentType) {
 
 try {
   if (ENFORCE !== '1' && ENFORCE !== 'true') process.exit(0);
+  if (FORCED) process.exit(0);
 
   mkdirSync(dirname(LOG_FILE), { recursive: true });
 

--- a/tests/enforce-model.sh
+++ b/tests/enforce-model.sh
@@ -129,7 +129,11 @@ enforce "$(mk_payload Agent crlf)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
 case "$ENFORCE_ERR" in *"model: sonnet)"*) ;; *) fail "crlf" "got '$ENFORCE_ERR'" ;; esac
 pass "crlf-frontmatter-parses"
 
-# --- Test 13: fail-open on garbage stdin ---
+# --- Test 13: CLAUDE_CODE_SUBAGENT_MODEL_FORCE overrides every model -> allow ---
+enforce "$(mk_payload Agent pinned)" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1 CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1
+allow "model-force-allows"
+
+# --- Test 14: fail-open on garbage stdin ---
 enforce "not json" CLAUDE_WATCHDOG_ENFORCE_SUBAGENT_MODEL=1
 [ "$ENFORCE_RC" -eq 0 ] || fail "fail-open" "expected exit 0, got $ENFORCE_RC"
 pass "fail-open"


### PR DESCRIPTION
Refs #42 (items 1 and 2 of the audit).

**Decision:** the enforce hook now exits 0 before reading stdin when `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` is set (non-empty, not `0`/`false`). Claude Code 2.1.257 ignores both per-spawn and definition models under that variable, so blocking a dispatch for a missing `model` would be pure friction with no effect on which model runs.

The hook itself stays. The native `Agent(model:opus)` permission rule (2.1.178) matches a parameter value and cannot express "parameter missing", so the two are complementary rather than redundant. The README section on pinned subagent models now says so in one paragraph, plus one sentence on the `FORCE` no-op.

<details>
<summary>Changes and evidence</summary>

- `hooks/enforce-subagent-model.mjs`: `FORCED` check right after the opt-in check, with a two-line comment stating the invariant.
- `tests/enforce-model.sh`: new case `model-force-allows` (enforce on, pinned agent, no model, `CLAUDE_CODE_SUBAGENT_MODEL_FORCE=1`) expects exit 0 and empty stderr. The old fail-open case is renumbered.
- `README.md`: one paragraph under "Enforcing pinned subagent models".

`just test` and `just lint` pass locally, including the new case.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEG4pXrebNqH2HhuTJ7gh7
