### PR TITLE
chore: ignore iCloud sync duplicate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .claude/
 reference
 tests/fixtures/large-session.jsonl
+# iCloud sync duplicates
+* 2.*
+* 2


### PR DESCRIPTION
Refs #42 (housekeeping item).

**Decision:** add `* 2.*` and `* 2` to `.gitignore` so iCloud's "name 2.ext" sync duplicates never show up as untracked files or get staged by accident.

The two existing duplicates, `hooks/enforce-subagent-model 2.mjs` and `tests/enforce-model 2.sh`, were verified byte-identical to their originals with `diff` and deleted locally. They were never tracked, so that deletion does not appear in this diff - the only change here is the two ignore patterns.

<details>
<summary>Evidence</summary>

- `diff -q` against both originals reported no differences before removal.
- `just test` passes on the branch (no source changes).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEG4pXrebNqH2HhuTJ7gh7
